### PR TITLE
Skip deploy if key is missing

### DIFF
--- a/.github/workflows/azure-static-web-apps-green-pebble-01f5d5c1e.yml
+++ b/.github/workflows/azure-static-web-apps-green-pebble-01f5d5c1e.yml
@@ -32,7 +32,7 @@ jobs:
         id: builddeploy
         uses: Azure/static-web-apps-deploy@v1
         with:
-          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_NONEXISTANT_01F5D5C1E }}
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_GREEN_PEBBLE_01F5D5C1E }}
           repo_token: ${{ secrets.GITHUB_TOKEN }} # Used for GitHub integrations (i.e. PR comments)
           action: "upload"
           ###### Repository/Build Configurations - These values can be configured to match your app requirements. ######
@@ -64,6 +64,6 @@ jobs:
         id: closepullrequest
         uses: Azure/static-web-apps-deploy@v1
         with:
-          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_NONEXISTANT_01F5D5C1E }}
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_GREEN_PEBBLE_01F5D5C1E }}
           action: "close"
           skip_deploy_on_missing_secrets: true

--- a/.github/workflows/azure-static-web-apps-green-pebble-01f5d5c1e.yml
+++ b/.github/workflows/azure-static-web-apps-green-pebble-01f5d5c1e.yml
@@ -42,7 +42,7 @@ jobs:
           # api_location: "" # Api source code path - optional
           output_location: "dist" # Built app content directory - optional
           production_branch: "production" # all other branches are preview builds
-          skip_deploy_on_missing_secrets: true
+          skip_deploy_on_missing_secrets: ${{ github.actor == 'dependabot[bot]' }}
         env:
           VITE_BUILD_MODE: |
             ${{
@@ -66,4 +66,4 @@ jobs:
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_GREEN_PEBBLE_01F5D5C1E }}
           action: "close"
-          skip_deploy_on_missing_secrets: true
+          skip_deploy_on_missing_secrets: ${{ github.actor == 'dependabot[bot]' }}

--- a/.github/workflows/azure-static-web-apps-green-pebble-01f5d5c1e.yml
+++ b/.github/workflows/azure-static-web-apps-green-pebble-01f5d5c1e.yml
@@ -42,6 +42,9 @@ jobs:
           # api_location: "" # Api source code path - optional
           output_location: "dist" # Built app content directory - optional
           production_branch: "production" # all other branches are preview builds
+          # dependabot forks the repo when making PRs, and doesn't have access
+          # to secrets (like the deploy key) in actions. This allows the CI to
+          # pass for dependabot PRs if the build succeeds.
           skip_deploy_on_missing_secrets: ${{ github.actor == 'dependabot[bot]' }}
         env:
           VITE_BUILD_MODE: |

--- a/.github/workflows/azure-static-web-apps-green-pebble-01f5d5c1e.yml
+++ b/.github/workflows/azure-static-web-apps-green-pebble-01f5d5c1e.yml
@@ -32,7 +32,7 @@ jobs:
         id: builddeploy
         uses: Azure/static-web-apps-deploy@v1
         with:
-          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_GREEN_PEBBLE_01F5D5C1E }}
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_NONEXISTANT_01F5D5C1E }}
           repo_token: ${{ secrets.GITHUB_TOKEN }} # Used for GitHub integrations (i.e. PR comments)
           action: "upload"
           ###### Repository/Build Configurations - These values can be configured to match your app requirements. ######
@@ -64,6 +64,6 @@ jobs:
         id: closepullrequest
         uses: Azure/static-web-apps-deploy@v1
         with:
-          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_GREEN_PEBBLE_01F5D5C1E }}
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_NONEXISTANT_01F5D5C1E }}
           action: "close"
           skip_deploy_on_missing_secrets: true

--- a/.github/workflows/azure-static-web-apps-green-pebble-01f5d5c1e.yml
+++ b/.github/workflows/azure-static-web-apps-green-pebble-01f5d5c1e.yml
@@ -42,6 +42,7 @@ jobs:
           # api_location: "" # Api source code path - optional
           output_location: "dist" # Built app content directory - optional
           production_branch: "production" # all other branches are preview builds
+          skip_deploy_on_missing_secrets: true
         env:
           VITE_BUILD_MODE: |
             ${{
@@ -65,3 +66,4 @@ jobs:
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_GREEN_PEBBLE_01F5D5C1E }}
           action: "close"
+          skip_deploy_on_missing_secrets: true


### PR DESCRIPTION
Allow Azure Static Web apps to pass check even if the deploy key is a missing secret (PR from a forked repo, such as `dependabot`).

Closes #153 

Note, this was tested with a fresh PR in #155. There the actions passed (green checks) but there was no deployment made and therefore no deployment comment, but there's no immediate positive indicator that while the site built successfully, there is no corresponding preview environment.

To reduce the chances of that happening, I've flagged that the site should only not deploy if the token is missing if the PR is from dependabot. If we end up having other bots open PRs, we can add them to the list, but I think this works for now.

Once we merge this, we should be able to rebase #146 and #147