### PR TITLE
Remove download data button

### DIFF
--- a/src/pages/ScenarioDetailPage.tsx
+++ b/src/pages/ScenarioDetailPage.tsx
@@ -3,7 +3,7 @@ import { useParams, Link } from "react-router-dom";
 import { scenariosData } from "../data/scenariosData";
 import { Scenario } from "../types";
 import Badge from "../components/Badge";
-import { Download, ExternalLink, ArrowLeft } from "lucide-react";
+import { ExternalLink, ArrowLeft } from "lucide-react";
 
 const ScenarioDetailPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
@@ -147,16 +147,6 @@ const ScenarioDetailPage: React.FC = () => {
                       />
                       Visit Source
                     </a>
-
-                    {scenario.dataSource.downloadAvailable && (
-                      <button className="inline-flex items-center px-4 py-2 bg-energy text-white rounded-md hover:bg-energy-700 transition-colors duration-200">
-                        <Download
-                          size={16}
-                          className="mr-2"
-                        />
-                        Download Data
-                      </button>
-                    )}
                   </div>
                 </div>
               </section>


### PR DESCRIPTION
This PR removes the 'Download data' button from the scenario details pages.

We're not going to provide data download functionality in this version of the app according to the product specifications.