### PR TITLE
Add net_zero_reached_year variable to the schema

### DIFF
--- a/pbtar_schema.json
+++ b/pbtar_schema.json
@@ -30,7 +30,7 @@
       "net_zero_reached_year": {
         "description": "Year by which net zero is reached in the scenario",
         "type": ["string", "null"],
-        "pattern": "^(20(3[0-9]|[4-9][0-9])|21[0-9][0-9])$"
+        "pattern": "^(20[3-9][0-9])|(21[0-9][0-9])$"
       },
       "target_year": {
         "description": "Target year of the scenario",

--- a/pbtar_schema.json
+++ b/pbtar_schema.json
@@ -29,8 +29,9 @@
       },
       "net_zero_reached_year": {
         "description": "Year by which net zero is reached in the scenario",
-        "type": ["string", "null"],
-        "pattern": "^(20(3[0-9]|[4-9][0-9])|21[0-9][0-9])$"
+        "type": ["integer", "null"],
+        "minimum": 2030,
+        "maximum": 2100
       },
       "target_year": {
         "description": "Target year of the scenario",

--- a/pbtar_schema.json
+++ b/pbtar_schema.json
@@ -30,7 +30,7 @@
       "net_zero_reached_year": {
         "description": "Year by which net zero is reached in the scenario",
         "type": ["string", "null"],
-        "pattern": "^(20[2-9][0-9]|21[0-9][0-9])$"
+        "pattern": "^(20(3[0-9]|[4-9][0-9])|21[0-9][0-9])$"
       },
       "target_year": {
         "description": "Target year of the scenario",

--- a/pbtar_schema.json
+++ b/pbtar_schema.json
@@ -27,6 +27,11 @@
         "description": "Detailed explanation of the scenario category",
         "type": "string"
       },
+      "net_zero_reached_year": {
+        "description": "Year by which net zero is reached in the scenario",
+        "type": ["string", "null"],
+        "pattern": "^(20[2-9][0-9]|21[0-9][0-9])$"
+      },
       "target_year": {
         "description": "Target year of the scenario",
         "type": "string"


### PR DESCRIPTION
First of the variables required by the data model draft provided by Climate Finance team added to the schema. The field is not required so it is omitted from the dummy data for now. The variable is specified as a `integer` with a minimum and maximum value as per Data model or `null` to make it robust.

NOTE: early implementation was setting the type to "string", however as per @AlexAxthelm feedback the "integer" was chosen in the end. See https://github.com/RMI/pbtar/pull/216#issuecomment-3101789227 for the discussion on string/integer and subsequent comments from @AlexAxthelm for the full discussion. Other year variables in the schema should follow suit in another PR. 