### PR TITLE
ci(GH Actions): Update required actions for `main` and `production`

### DIFF
--- a/.github/rulesets/gitflow-main.json
+++ b/.github/rulesets/gitflow-main.json
@@ -40,7 +40,19 @@
         "do_not_enforce_on_create": false,
         "required_status_checks": [
           {
+            "context": "Build / Release Preview",
+            "integration_id": 15368
+          },
+          {
+            "context": "Deploy to SWA / Build and Deploy Job",
+            "integration_id": 15368
+          },
+          {
             "context": "Formatting / Run Prettier Check",
+            "integration_id": 15368
+          },
+          {
+            "context": "JSON Schema Validation / Check Schema Docs",
             "integration_id": 15368
           },
           {
@@ -49,6 +61,10 @@
           },
           {
             "context": "Linting / Run ESLint",
+            "integration_id": 15368
+          },
+          {
+            "context": "Unit Tests / Run unit tests",
             "integration_id": 15368
           }
         ]

--- a/.github/rulesets/gitflow-production.json
+++ b/.github/rulesets/gitflow-production.json
@@ -40,7 +40,19 @@
         "do_not_enforce_on_create": false,
         "required_status_checks": [
           {
+            "context": "Build and Release / Build and Release",
+            "integration_id": 15368
+          },
+          {
+            "context": "Deploy to SWA / Build and Deploy Job",
+            "integration_id": 15368
+          },
+          {
             "context": "Formatting / Run Prettier Check",
+            "integration_id": 15368
+          },
+          {
+            "context": "JSON Schema Validation / Check Schema Docs",
             "integration_id": 15368
           },
           {
@@ -49,6 +61,10 @@
           },
           {
             "context": "Linting / Run ESLint",
+            "integration_id": 15368
+          },
+          {
+            "context": "Unit Tests / Run unit tests",
             "integration_id": 15368
           }
         ]


### PR DESCRIPTION
Adds required actions for PRs (admins can still bypass), to restore general behavior (all lints, tests, etc must pass, and deploy must be sucessful) from before #275.

Closes #279

----

## Note to reviewers

**"Rulesets Checks / Check GH rulesets (pull_request)"** is expected to fail at this point. For PRs that change rulesets, I've been comfortable with getting an approval on the PR (expected behavior), updating the ruleset in-repo ("Settings"), and re-triggering the failing check (which should come back green this time), and then merging.