### PR TITLE
ci(GH Actions): set concurrency group to ref (branch) level

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -17,7 +17,9 @@ on:
       - next
 
 name: Node Package Checks
-concurrency: node-package-checks
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   linting:


### PR DESCRIPTION
Previously, any `node-package-checks` (across branches/PRs) would conflict in the same concurrency group, meaning that in busy CI situations, some would be cancelled as subsequent events queued up behind them (and PRs would never get required checks).

This sets concurrency groups per-branch (technically per `ref`), meaning that actions across branches/PRs run independently.

Additionally, setting `cancel-in-progress` means that only the latest update on a ref will run, as when a new run in the same concurrency group will cancel previous ones (updates will come from latest).

Closes #350 