### PR TITLE
Feat/348 links in new tab

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "react-dom": "^19.1.1",
         "react-markdown": "^10.1.0",
         "react-router-dom": "^7.8.2",
+        "rehype-external-links": "^3.0.0",
         "vite-plugin-static-copy": "^3.1.2"
       },
       "devDependencies": {
@@ -5370,6 +5371,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/hast-util-is-element": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+      "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-jsx-runtime": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
@@ -5656,6 +5670,18 @@
       },
       "engines": {
         "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-absolute-url": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-4.0.1.tgz",
+      "integrity": "sha512-/51/TKE88Lmm7Gc4/8btclNXWS+g50wXhYJq8HWIBAGUBnoAdRu1aXeh364t/O7wXDAcTJDP8PNuNKWUDWie+A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -10937,6 +10963,24 @@
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/rehype-external-links": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-external-links/-/rehype-external-links-3.0.0.tgz",
+      "integrity": "sha512-yp+e5N9V3C6bwBeAC4n796kc86M4gJCdlVhiMTxIrJG5UHDMh+PJANf9heqORJbt1nrCbDwIlAZKjANIaVBbvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "is-absolute-url": "^4.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/remark-parse": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "react-dom": "^19.1.1",
     "react-markdown": "^10.1.0",
     "react-router-dom": "^7.8.2",
+    "rehype-external-links": "^3.0.0",
     "vite-plugin-static-copy": "^3.1.2"
   },
   "devDependencies": {

--- a/src/components/Markdown.test.tsx
+++ b/src/components/Markdown.test.tsx
@@ -1,26 +1,31 @@
+import { describe, it, expect } from "vitest";
 import { render, screen, within } from "@testing-library/react";
 import Markdown from "./Markdown";
 
 describe("Markdown external link behavior", () => {
   it("adds target/rel only to http/https links (explicit https)", () => {
     render(<Markdown>[link](https://example.com)</Markdown>);
-    const a = screen.getByRole("link", { name: "link" }) as HTMLAnchorElement;
-    expect(a.href).toBe("https://example.com/");
-    expect(a.target).toBe("_blank");
-    expect(a.rel.split(" ").sort()).toEqual(["noreferrer", "noopener"].sort());
+    const link = screen.getByRole("link", { name: "link" });
+    expect(link).toBeInTheDocument();
+    expect(link.getAttribute("href")).toBe("https://example.com");
+    expect(link.getAttribute("target")).toBe("_blank");
+    const rel = (link.getAttribute("rel") ?? "").split(" ").sort();
+    expect(rel).toEqual(["noopener", "noreferrer"].sort());
   });
 
   it("adds target/rel only to http/https links (explicit http)", () => {
     render(<Markdown>[link](http://example.com)</Markdown>);
-    const a = screen.getByRole("link", { name: "link" }) as HTMLAnchorElement;
-    expect(a.href).toBe("http://example.com/");
-    expect(a.target).toBe("_blank");
-    expect(a.rel.split(" ").sort()).toEqual(["noreferrer", "noopener"].sort());
+    const link = screen.getByRole("link", { name: "link" });
+    expect(link).toBeInTheDocument();
+    expect(link.getAttribute("href")).toBe("http://example.com");
+    expect(link.getAttribute("target")).toBe("_blank");
+    const rel = (link.getAttribute("rel") ?? "").split(" ").sort();
+    expect(rel).toEqual(["noopener", "noreferrer"].sort());
   });
 
   it("does not touch site-internal hash anchors", () => {
     render(<Markdown>[jump](#section)</Markdown>);
-    const a = screen.getByRole("link", { name: "jump" }) as HTMLAnchorElement;
+    const a = screen.getByRole("link", { name: "jump" });
     // unchanged target/rel
     expect(a.target).toBe("");
     expect(a.rel).toBe("");
@@ -29,14 +34,14 @@ describe("Markdown external link behavior", () => {
 
   it("does not force target on relative paths", () => {
     render(<Markdown>[Home](/)</Markdown>);
-    const a = screen.getByRole("link", { name: "Home" }) as HTMLAnchorElement;
+    const a = screen.getByRole("link", { name: "Home" });
     expect(a.target).toBe("");
     expect(a.rel).toBe("");
   });
 
   it("does not modify non-http schemes like mailto:", () => {
     render(<Markdown>[Email](mailto:test@example.org)</Markdown>);
-    const a = screen.getByRole("link", { name: "Email" }) as HTMLAnchorElement;
+    const a = screen.getByRole("link", { name: "Email" });
     expect(a.target).toBe("");
     expect(a.rel).toBe("");
     expect(a.href).toBe("mailto:test@example.org");
@@ -49,7 +54,7 @@ describe("Markdown external link behavior", () => {
       </Markdown>,
     );
     const links = screen.getAllByRole("link");
-    const [ext, int, hash, ext2] = links as HTMLAnchorElement[];
+    const [ext, int, hash, ext2] = links;
     expect(ext.target).toBe("_blank");
     expect(ext2.target).toBe("_blank");
     expect(int.target).toBe("");
@@ -58,7 +63,7 @@ describe("Markdown external link behavior", () => {
 
   it("preserves link titles and still adds target/rel", () => {
     render(<Markdown>[titled](https://example.com "Example Title")</Markdown>);
-    const a = screen.getByRole("link", { name: "titled" }) as HTMLAnchorElement;
+    const a = screen.getByRole("link", { name: "titled" });
     expect(a.title).toBe("Example Title");
     expect(a.target).toBe("_blank");
     expect(a.rel).toContain("noopener");
@@ -71,7 +76,7 @@ describe("Markdown safety/other elements", () => {
     render(<Markdown>![alt text](/img/logo.png)</Markdown>);
     const img = screen.getByRole("img", {
       name: "alt text",
-    }) as HTMLImageElement;
+    });
     expect(img.src).toMatch(/\/img\/logo\.png$/);
   });
 
@@ -79,7 +84,7 @@ describe("Markdown safety/other elements", () => {
     render(
       <Markdown>{`[![alt](/img/logo.png)](https://example.com)`}</Markdown>,
     );
-    const link = screen.getByRole("link") as HTMLAnchorElement;
+    const link = screen.getByRole("link");
     expect(link.target).toBe("_blank");
     expect(link.rel).toContain("noopener");
     expect(link.rel).toContain("noreferrer");

--- a/src/components/Markdown.test.tsx
+++ b/src/components/Markdown.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen, within } from "@testing-library/react";
+import Markdown from "./Markdown";
+
+describe("Markdown external link behavior", () => {
+  it("adds target/rel only to http/https links (explicit https)", () => {
+    render(<Markdown>[link](https://example.com)</Markdown>);
+    const a = screen.getByRole("link", { name: "link" }) as HTMLAnchorElement;
+    expect(a.href).toBe("https://example.com/");
+    expect(a.target).toBe("_blank");
+    expect(a.rel.split(" ").sort()).toEqual(["noreferrer", "noopener"].sort());
+  });
+
+  it("adds target/rel only to http/https links (explicit http)", () => {
+    render(<Markdown>[link](http://example.com)</Markdown>);
+    const a = screen.getByRole("link", { name: "link" }) as HTMLAnchorElement;
+    expect(a.href).toBe("http://example.com/");
+    expect(a.target).toBe("_blank");
+    expect(a.rel.split(" ").sort()).toEqual(["noreferrer", "noopener"].sort());
+  });
+
+  it("does not touch site-internal hash anchors", () => {
+    render(<Markdown>[jump](#section)</Markdown>);
+    const a = screen.getByRole("link", { name: "jump" }) as HTMLAnchorElement;
+    // unchanged target/rel
+    expect(a.target).toBe("");
+    expect(a.rel).toBe("");
+    expect(a.getAttribute("href")).toBe("#section");
+  });
+
+  it("does not force target on relative paths", () => {
+    render(<Markdown>[Home](/)</Markdown>);
+    const a = screen.getByRole("link", { name: "Home" }) as HTMLAnchorElement;
+    expect(a.target).toBe("");
+    expect(a.rel).toBe("");
+  });
+
+  it("does not modify non-http schemes like mailto:", () => {
+    render(<Markdown>[Email](mailto:test@example.org)</Markdown>);
+    const a = screen.getByRole("link", { name: "Email" }) as HTMLAnchorElement;
+    expect(a.target).toBe("");
+    expect(a.rel).toBe("");
+    expect(a.href).toBe("mailto:test@example.org");
+  });
+
+  it("handles multiple links and only modifies the externals", () => {
+    render(
+      <Markdown>
+        {`[ext](http://example.com) [int](/docs) [hash](#id) [ext2](https://rmi.org)`}
+      </Markdown>,
+    );
+    const links = screen.getAllByRole("link");
+    const [ext, int, hash, ext2] = links as HTMLAnchorElement[];
+    expect(ext.target).toBe("_blank");
+    expect(ext2.target).toBe("_blank");
+    expect(int.target).toBe("");
+    expect(hash.target).toBe("");
+  });
+
+  it("preserves link titles and still adds target/rel", () => {
+    render(<Markdown>[titled](https://example.com "Example Title")</Markdown>);
+    const a = screen.getByRole("link", { name: "titled" }) as HTMLAnchorElement;
+    expect(a.title).toBe("Example Title");
+    expect(a.target).toBe("_blank");
+    expect(a.rel).toContain("noopener");
+    expect(a.rel).toContain("noreferrer");
+  });
+});
+
+describe("Markdown safety/other elements", () => {
+  it("does not alter images; only anchors receive target/rel", () => {
+    render(<Markdown>![alt text](/img/logo.png)</Markdown>);
+    const img = screen.getByRole("img", {
+      name: "alt text",
+    }) as HTMLImageElement;
+    expect(img.src).toMatch(/\/img\/logo\.png$/);
+  });
+
+  it("works when a link wraps an image; the anchor should get target/rel", () => {
+    render(
+      <Markdown>{`[![alt](/img/logo.png)](https://example.com)`}</Markdown>,
+    );
+    const link = screen.getByRole("link") as HTMLAnchorElement;
+    expect(link.target).toBe("_blank");
+    expect(link.rel).toContain("noopener");
+    expect(link.rel).toContain("noreferrer");
+    const img = within(link).getByRole("img", { name: "alt" });
+    expect(img).toBeInTheDocument();
+  });
+});

--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -9,7 +9,12 @@ export default function Markdown({ children }: Props) {
   return (
     <ReactMarkdown
       // Only external links get target/rel; internal anchors remain untouched.
-      rehypePlugins={[[rehypeExternalLinks, { target: "_blank", rel: ["noopener", "noreferrer"] }]]}
+      rehypePlugins={[
+        [
+          rehypeExternalLinks,
+          { target: "_blank", rel: ["noopener", "noreferrer"] },
+        ],
+      ]}
     >
       {children}
     </ReactMarkdown>

--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import ReactMarkdown from "react-markdown";
+import rehypeExternalLinks from "rehype-external-links";
+
+type Props = { children: string };
+
+// Centralizes our markdown behavior (target, rel, future plugins).
+export default function Markdown({ children }: Props) {
+  return (
+    <ReactMarkdown
+      // Only external links get target/rel; internal anchors remain untouched.
+      rehypePlugins={[[rehypeExternalLinks, { target: "_blank", rel: ["noopener", "noreferrer"] }]]}
+    >
+      {children}
+    </ReactMarkdown>
+  );
+}

--- a/src/pages/ScenarioDetailPage.tsx
+++ b/src/pages/ScenarioDetailPage.tsx
@@ -141,9 +141,7 @@ const ScenarioDetailPage: React.FC = () => {
                 </h2>
                 <div className="bg-neutral-50 border border-neutral-200 rounded-lg p-4">
                   <div className="text-rmigray-700 mb-4 [&_a]:text-energy [&_a]:hover:text-energy-700">
-                    <Markdown>
-                      {scenario.dataSource.description}
-                    </Markdown>
+                    <Markdown>{scenario.dataSource.description}</Markdown>
                   </div>
                   <div className="flex flex-col sm:flex-row gap-3">
                     <a

--- a/src/pages/ScenarioDetailPage.tsx
+++ b/src/pages/ScenarioDetailPage.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { useParams, Link } from "react-router-dom";
-import ReactMarkdown from "react-markdown";
+import Markdown from "../components/Markdown";
 import { scenariosData } from "../data/scenariosData";
 import { Scenario, PathwayType } from "../types";
 import Badge from "../components/Badge";
@@ -122,7 +122,7 @@ const ScenarioDetailPage: React.FC = () => {
                   Scenario Overview
                 </h2>
                 <div className="prose text-rmigray-700">
-                  <ReactMarkdown>{scenario.overview}</ReactMarkdown>
+                  <Markdown>{scenario.overview}</Markdown>
                 </div>
               </section>
 
@@ -131,7 +131,7 @@ const ScenarioDetailPage: React.FC = () => {
                   Expert Recommendations
                 </h2>
                 <div className="prose text-rmigray-700">
-                  <ReactMarkdown>{scenario.expertRecommendation}</ReactMarkdown>
+                  <Markdown>{scenario.expertRecommendation}</Markdown>
                 </div>
               </section>
 
@@ -141,9 +141,9 @@ const ScenarioDetailPage: React.FC = () => {
                 </h2>
                 <div className="bg-neutral-50 border border-neutral-200 rounded-lg p-4">
                   <div className="text-rmigray-700 mb-4 [&_a]:text-energy [&_a]:hover:text-energy-700">
-                    <ReactMarkdown>
+                    <Markdown>
                       {scenario.dataSource.description}
-                    </ReactMarkdown>
+                    </Markdown>
                   </div>
                   <div className="flex flex-col sm:flex-row gap-3">
                     <a


### PR DESCRIPTION
Add markdown component which standardizes rendering for Markdown content, including opening links in new tab