### PR TITLE
fix(data model): Use modelYearNetzero not modelYearEnd for target

### DIFF
--- a/src/components/ScenarioCard.test.tsx
+++ b/src/components/ScenarioCard.test.tsx
@@ -88,7 +88,7 @@ describe("ScenarioCard component", () => {
   it("shows target year and temperature badges", () => {
     renderScenarioCard();
 
-    expect(screen.getByText(mockScenario.modelYearEnd)).toBeInTheDocument();
+    expect(screen.getByText(mockScenario.modelYearNetzero)).toBeInTheDocument();
     expect(
       screen.getByText(mockScenario.modelTempIncrease?.toString() + "°C"),
     ).toBeInTheDocument();
@@ -388,7 +388,7 @@ describe("tooltip functionality", () => {
       const s: Scenario = {
         ...mockScenario,
         // Using a double cast to satisfy TS, but this still presents as numeric at runtime.
-        modelYearEnd: 2030 as unknown as string, // number on purpose
+        modelYearNetzero: 2030 as unknown as string, // number on purpose
         publicationYear: 2024 as unknown as string, // number
       };
 
@@ -422,7 +422,7 @@ describe("tooltip functionality", () => {
       const s: Scenario = {
         ...mockScenario,
         // Using a double cast to satisfy TS, but this still presents as null/undefined at runtime.
-        modelYearEnd: 2045 as unknown as string, // number on purpose
+        modelYearNetzero: 2045 as unknown as string, // number on purpose
       };
       const { container } = renderWithRouter(s, "2045");
       const marks = container.querySelectorAll("mark");

--- a/src/components/ScenarioCard.tsx
+++ b/src/components/ScenarioCard.tsx
@@ -175,7 +175,7 @@ const ScenarioCard: React.FC<ScenarioCardProps> = ({
               variant="year"
               renderLabel={(label) => highlightTextIfSearchMatch(label)}
             >
-              {scenario.modelYearEnd}
+              {scenario.modelYearNetzero}
             </BadgeMaybeAbsent>
             <BadgeMaybeAbsent
               variant="temperature"

--- a/src/components/SearchSection.tsx
+++ b/src/components/SearchSection.tsx
@@ -37,7 +37,7 @@ const SearchSection: React.FC<SearchSectionProps> = ({
         | "sector"
         | "metric"
         | "pathwayType"
-        | "modelYearEnd"
+        | "modelYearNetzero"
         | "modelTempIncrease",
       m: FacetMode,
     ) => {
@@ -50,8 +50,8 @@ const SearchSection: React.FC<SearchSectionProps> = ({
     scenariosData.map((d) => d.pathwayType),
   );
 
-  const modelYearEndOptions = buildOptionsFromValues(
-    scenariosData.map((d) => d.modelYearEnd),
+  const modelYearNetzeroOptions = buildOptionsFromValues(
+    scenariosData.map((d) => d.modelYearNetzero),
   );
 
   const temperatureOptions = buildOptionsFromValues(
@@ -96,9 +96,9 @@ const SearchSection: React.FC<SearchSectionProps> = ({
     (Array.isArray(filters.metric)
       ? filters.metric.length > 0
       : filters.metric != null) ||
-    (Array.isArray(filters.modelYearEnd)
-      ? filters.modelYearEnd.length > 0
-      : filters.modelYearEnd != null) ||
+    (Array.isArray(filters.modelYearNetzero)
+      ? filters.modelYearNetzero.length > 0
+      : filters.modelYearNetzero != null) ||
     (Array.isArray(filters.modelTempIncrease)
       ? filters.modelTempIncrease.length > 0
       : filters.modelTempIncrease != null);
@@ -127,12 +127,12 @@ const SearchSection: React.FC<SearchSectionProps> = ({
 
         <MultiSelectDropdown<number>
           label="Target Year"
-          options={modelYearEndOptions}
-          value={filters.modelYearEnd}
-          onChange={(arr) => onFilterChange("modelYearEnd", arr)}
+          options={modelYearNetzeroOptions}
+          value={filters.modelYearNetzero}
+          onChange={(arr) => onFilterChange("modelYearNetzero", arr)}
           showModeToggle={false}
-          mode={filters.modes?.modelYearEnd ?? "ANY"}
-          onModeChange={(m) => setMode("modelYearEnd", m)}
+          mode={filters.modes?.modelYearNetzero ?? "ANY"}
+          onModeChange={(m) => setMode("modelYearNetzero", m)}
         />
 
         <MultiSelectDropdown<string | number>

--- a/src/pages/HomePage.test.tsx
+++ b/src/pages/HomePage.test.tsx
@@ -69,7 +69,7 @@ describe("HomePage integration: dropdowns render and filter with 'None'", () => 
       geography: undefined, // -> Geography "None"
       modelTempIncrease: undefined, // -> Temperature "None"
       pathwayType: "Net Zero",
-      modelYearEnd: 2050,
+      modelYearNetzero: 2050,
       metric: [],
     },
     {
@@ -79,7 +79,7 @@ describe("HomePage integration: dropdowns render and filter with 'None'", () => 
       geography: ["Europe"],
       modelTempIncrease: "2°C",
       pathwayType: "Net Zero",
-      modelYearEnd: 2050,
+      modelYearNetzero: 2050,
       metric: ["Capacity"],
     },
     {
@@ -89,7 +89,7 @@ describe("HomePage integration: dropdowns render and filter with 'None'", () => 
       geography: [], // -> Geography "None"
       modelTempIncrease: "1.5°C",
       pathwayType: "NZi2050",
-      modelYearEnd: 2040,
+      modelYearNetzero: 2040,
       metric: [],
     },
     {
@@ -99,7 +99,7 @@ describe("HomePage integration: dropdowns render and filter with 'None'", () => 
       geography: ["Asia"],
       modelTempIncrease: undefined, // -> Temperature "None"
       pathwayType: "BAU",
-      modelYearEnd: 2030,
+      modelYearNetzero: 2030,
       metric: ["Capacity", "Generation"],
     },
     {
@@ -109,7 +109,7 @@ describe("HomePage integration: dropdowns render and filter with 'None'", () => 
       geography: ["Europe", "Asia"],
       modelTempIncrease: "2°C",
       pathwayType: "Net Zero",
-      modelYearEnd: 2050,
+      modelYearNetzero: 2050,
       metric: ["Generation"],
     },
   ] as const;

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -16,7 +16,7 @@ const HomePage: React.FC = () => {
 
   const [filters, setFilters] = useState<SearchFilters>({
     pathwayType: null,
-    modelYearEnd: null,
+    modelYearNetzero: null,
     modelTempIncrease: null,
     geography: null,
     sector: null,
@@ -41,7 +41,7 @@ const HomePage: React.FC = () => {
       const hasFilterChanged =
         filters.searchTerm !== prevFiltersRef.current.searchTerm ||
         filters.pathwayType !== prevFiltersRef.current.pathwayType ||
-        filters.modelYearEnd !== prevFiltersRef.current.modelYearEnd ||
+        filters.modelYearNetzero !== prevFiltersRef.current.modelYearNetzero ||
         filters.modelTempIncrease !==
           prevFiltersRef.current.modelTempIncrease ||
         filters.geography !== prevFiltersRef.current.geography ||
@@ -100,7 +100,7 @@ const HomePage: React.FC = () => {
   const handleClear = () => {
     setFilters({
       pathwayType: null,
-      modelYearEnd: null,
+      modelYearNetzero: null,
       modelTempIncrease: null,
       geography: null,
       sector: null,

--- a/src/pages/ScenarioDetailPage.tsx
+++ b/src/pages/ScenarioDetailPage.tsx
@@ -102,7 +102,7 @@ const ScenarioDetailPage: React.FC = () => {
               {scenario.pathwayType}
             </BadgeMaybeAbsent>
             <BadgeMaybeAbsent variant="year">
-              {scenario.modelYearEnd}
+              {scenario.modelYearNetzero}
             </BadgeMaybeAbsent>
             <BadgeMaybeAbsent
               variant="temperature"

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,6 +6,7 @@ export interface Scenario {
   description: string;
   pathwayType: string;
   modelYearEnd: string;
+  modelYearNetzero?: number;
   modelTempIncrease?: number;
   geography: string[];
   metric: string[];
@@ -66,7 +67,7 @@ export type Metric =
 
 export interface SearchFilters {
   pathwayType?: string | string[] | null;
-  modelYearEnd?: number | (number | string)[] | null;
+  modelYearNetzero?: number | (number | string)[] | null;
   modelTempIncrease?: number | string | (number | string)[] | null;
   geography?: string | string[] | null;
   sector?: string | string[] | null;
@@ -75,7 +76,7 @@ export interface SearchFilters {
   // Optional per-facet mode (used later by a UI toggle)
   modes?: {
     pathwayType?: FacetMode;
-    modelYearEnd?: FacetMode;
+    modelYearNetzero?: FacetMode;
     modelTempIncrease?: FacetMode;
     geography?: FacetMode;
     sector?: FacetMode;

--- a/src/utils/searchUtils.test.tsx
+++ b/src/utils/searchUtils.test.tsx
@@ -27,15 +27,11 @@ describe("searchUtils", () => {
     });
 
     it("filters by target year", () => {
-      const filters: SearchFilters = { modelYearEnd: 2050 };
+      const filters: SearchFilters = { modelYearNetzero: 2050 };
       const result = filterScenarios(mockScenarios, filters);
 
-      expect(result.length).toBe(3);
-      expect(result.map((x) => x.id)).toEqual([
-        "sample-01",
-        "sample-02",
-        "sample-04",
-      ]);
+      expect(result.length).toBe(2);
+      expect(result.map((x) => x.id)).toEqual(["sample-01", "sample-04"]);
     });
 
     it("filters by modeled temperature increase", () => {
@@ -100,7 +96,7 @@ describe("searchUtils", () => {
     it("returns empty array when no scenarios match filters", () => {
       const filters: SearchFilters = {
         pathwayType: "Policy",
-        modelYearEnd: "2030",
+        modelYearNetzero: "2030",
       };
       const result = filterScenarios(mockScenarios, filters);
 
@@ -137,18 +133,14 @@ describe("searchUtils", () => {
     });
 
     it("safely omits results for non-existing fields", () => {
-      //scenario 3 in the mock data has no modelYearEnd
+      //scenario 3 in the mock data has no modelYearNetzero
       const filters: SearchFilters = {
-        modelYearEnd: 2050,
+        modelYearNetzero: 2050,
       };
 
       const result = filterScenarios(mockScenarios, filters);
-      expect(result.length).toBe(3);
-      expect(result.map((x) => x.id)).toEqual([
-        "sample-01",
-        "sample-02",
-        "sample-04",
-      ]);
+      expect(result.length).toBe(2);
+      expect(result.map((x) => x.id)).toEqual(["sample-01", "sample-04"]);
     });
   });
 });
@@ -223,7 +215,7 @@ describe("filterScenarios (array-backed facets)", () => {
       geography: undefined,
       modelTempIncrease: undefined,
       pathwayType: undefined,
-      modelYearEnd: undefined,
+      modelYearNetzero: undefined,
       publisher: undefined,
       publicationYear: undefined,
       description: undefined,
@@ -235,7 +227,7 @@ describe("filterScenarios (array-backed facets)", () => {
       geography: ["Europe"],
       modelTempIncrease: 2.0,
       pathwayType: "Direct Policy",
-      modelYearEnd: 2040,
+      modelYearNetzero: 2040,
       publisher: "X",
       publicationYear: 2020,
       description: "",
@@ -247,7 +239,7 @@ describe("filterScenarios (array-backed facets)", () => {
       geography: ["Asia"],
       modelTempIncrease: 1.5,
       pathwayType: "Exploratory",
-      modelYearEnd: 2030,
+      modelYearNetzero: 2030,
       publisher: "X",
       publicationYear: 2020,
       description: "",
@@ -271,21 +263,21 @@ describe("filterScenarios (array-backed facets)", () => {
     expect(out.map((s) => s.id)).toEqual(["A"]);
   });
 
-  it("numeric (modelYearEnd): OR over numbers, with ABSENT", () => {
+  it("numeric (modelYearNetzero): OR over numbers, with ABSENT", () => {
     let out = filterScenarios(scenarios, {
-      modelYearEnd: [2040, 2030],
+      modelYearNetzero: [2040, 2030],
     } as FiltersWithArrays);
     expect(out.map((s) => s.id)).toEqual(["B", "C"]);
     out = filterScenarios(scenarios, {
-      modelYearEnd: [2040, ABSENT_FILTER_TOKEN],
+      modelYearNetzero: [2040, ABSENT_FILTER_TOKEN],
     } as FiltersWithArrays);
     expect(out.map((s) => s.id)).toEqual(["A", "B"]);
     out = filterScenarios(scenarios, {
-      modelYearEnd: [ABSENT_FILTER_TOKEN],
+      modelYearNetzero: [ABSENT_FILTER_TOKEN],
     } as FiltersWithArrays);
     expect(out.map((s) => s.id)).toEqual(["A"]);
     out = filterScenarios(scenarios, {
-      modelYearEnd: [9999],
+      modelYearNetzero: [9999],
     } as FiltersWithArrays);
     expect(out.map((s) => s.id)).toEqual([]);
   });
@@ -335,7 +327,7 @@ describe("filterScenarios (array-backed facets)", () => {
           geography: [],
           modelTempIncrease: 2,
           pathwayType: "Net Zero",
-          modelYearEnd: 2050,
+          modelYearNetzero: 2050,
           publisher: "",
           publicationYear: 2020,
           description: "",
@@ -347,7 +339,7 @@ describe("filterScenarios (array-backed facets)", () => {
           geography: [],
           modelTempIncrease: 1.5,
           pathwayType: "BAU",
-          modelYearEnd: 2030,
+          modelYearNetzero: 2030,
           publisher: "",
           publicationYear: 2020,
           description: "",
@@ -358,7 +350,7 @@ describe("filterScenarios (array-backed facets)", () => {
     expect(out).toHaveLength(0);
   });
 
-  it("modelYearEnd: ALL with [2030,2050] yields no results (single-valued facet)", () => {
+  it("modelYearNetzero: ALL with [2030,2050] yields no results (single-valued facet)", () => {
     const out = filterScenarios(
       [
         {
@@ -368,7 +360,7 @@ describe("filterScenarios (array-backed facets)", () => {
           geography: [],
           modelTempIncrease: 2,
           pathwayType: "X",
-          modelYearEnd: 2030,
+          modelYearNetzero: 2030,
           publisher: "",
           publicationYear: 2020,
           description: "",
@@ -380,13 +372,13 @@ describe("filterScenarios (array-backed facets)", () => {
           geography: [],
           modelTempIncrease: 2,
           pathwayType: "Y",
-          modelYearEnd: 2050,
+          modelYearNetzero: 2050,
           publisher: "",
           publicationYear: 2020,
           description: "",
         },
       ] as Scenario[],
-      { modelYearEnd: [2030, 2050], modes: { modelYearEnd: "ALL" } },
+      { modelYearNetzero: [2030, 2050], modes: { modelYearNetzero: "ALL" } },
     );
     expect(out).toHaveLength(0);
   });
@@ -401,7 +393,7 @@ describe("filterScenarios (array-backed facets)", () => {
           geography: [],
           modelTempIncrease: 1.5,
           pathwayType: "X",
-          modelYearEnd: 2030,
+          modelYearNetzero: 2030,
           publisher: "",
           publicationYear: 2020,
           description: "",
@@ -413,7 +405,7 @@ describe("filterScenarios (array-backed facets)", () => {
           geography: [],
           modelTempIncrease: 2.0,
           pathwayType: "Y",
-          modelYearEnd: 2050,
+          modelYearNetzero: 2050,
           publisher: "",
           publicationYear: 2020,
           description: "",
@@ -434,7 +426,7 @@ describe("filterScenarios (array-backed facets)", () => {
           geography: [],
           modelTempIncrease: null,
           pathwayType: null,
-          modelYearEnd: null,
+          modelYearNetzero: null,
           publisher: "",
           publicationYear: 2020,
           description: "",
@@ -453,7 +445,7 @@ describe("filterScenarios (array-backed facets)", () => {
           geography: [],
           modelTempIncrease: 2.0,
           pathwayType: "Net Zero",
-          modelYearEnd: 2030,
+          modelYearNetzero: 2030,
           publisher: "",
           publicationYear: 2020,
           description: "",

--- a/src/utils/searchUtils.ts
+++ b/src/utils/searchUtils.ts
@@ -16,7 +16,7 @@ export interface GeoOption {
 export type FacetMode = "ANY" | "ALL";
 export type FilterModes = Partial<{
   pathwayType: FacetMode;
-  modelYearEnd: FacetMode;
+  modelYearNetzero: FacetMode;
   modelTempIncrease: FacetMode;
   geography: FacetMode;
   sector: FacetMode;
@@ -39,7 +39,7 @@ export type FiltersWithArrays = {
   sector?: Arrayable;
   metric?: Arrayable;
   pathwayType?: Arrayable;
-  modelYearEnd?: Arrayable;
+  modelYearNetzero?: Arrayable;
   modelTempIncrease?: Arrayable;
   searchTerm?: string;
   // optional
@@ -130,12 +130,12 @@ export const filterScenarios = (
 
     // ---- Target year: OR over numbers; empty array => no filter; ABSENT-aware
     {
-      const selected = toArrayMixed(filters.modelYearEnd);
+      const selected = toArrayMixed(filters.modelYearNetzero);
       if (selected.length) {
         const hasAbsent = hasAbsentToken(selected);
         const numericChoices = toNumberSet(selected);
-        const v = scenario.modelYearEnd; // number | null | undefined
-        const mode = pickMode("modelYearEnd", filters.modes as FilterModes);
+        const v = scenario.modelYearNetzero; // number | null | undefined
+        const mode = pickMode("modelYearNetzero", filters.modes as FilterModes);
         let ok = true;
 
         if (mode === "ANY") {
@@ -246,7 +246,7 @@ export const filterScenarios = (
         scenario.name,
         scenario.description,
         scenario.pathwayType,
-        scenario.modelYearEnd,
+        scenario.modelYearNetzero,
         scenario.modelTempIncrease,
         ...scenario.geography,
         ...scenario.geography.map((s) => geographyLabel(s)),


### PR DESCRIPTION
Closes #380

when we modified the schema to include `modelYearNetzero` instead of just `modelYearEnd`, the previously used `modelYearEnd` was kept in the UI and search behavior. This commits changes the relevant (not all) locations related to filter, search, and UI