### PR TITLE
fix(details page): Show all badges in array

### DIFF
--- a/src/pages/ScenarioDetailPage.tsx
+++ b/src/pages/ScenarioDetailPage.tsx
@@ -186,6 +186,7 @@ const ScenarioDetailPage: React.FC = () => {
                     (geo) => geographyVariant(geographyKind(geo)) as string,
                   )}
                   toLabel={(geo) => geographyLabel(normalizeGeography(geo))}
+                  visibleCount={Infinity}
                 >
                   {sortGeographiesForDetails(scenario.geography ?? [])}
                 </BadgeArray>
@@ -203,6 +204,7 @@ const ScenarioDetailPage: React.FC = () => {
                   <BadgeArray
                     variant="sector"
                     tooltipGetter={getSectorTooltip}
+                    visibleCount={Infinity}
                   >
                     {scenario.sectors.map((sector) => sector.name)}
                   </BadgeArray>
@@ -216,6 +218,7 @@ const ScenarioDetailPage: React.FC = () => {
                 <BadgeArray
                   variant="metric"
                   tooltipGetter={getMetricTooltip}
+                  visibleCount={Infinity}
                 >
                   {scenario.metric}
                 </BadgeArray>


### PR DESCRIPTION
Updates to the `BadgeArray` component led to only one row of badges being displayed in the details page, rather than all of them.