### PR TITLE
docs: add contributing and code of conduct guides

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,10 @@
+# Code of Conduct
+
+We are committed to fostering a welcoming and inclusive environment for everyone.
+
+- Be respectful and considerate.
+- Harassment, discrimination, or abusive behavior will not be tolerated.
+- Communicate constructively and with empathy.
+- Respect differing viewpoints and experiences.
+
+Let’s work together to keep this project a positive space to work together.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -7,4 +7,4 @@ We are committed to fostering a welcoming and inclusive environment for everyone
 - Communicate constructively and with empathy.
 - Respect differing viewpoints and experiences.
 
-Let’s work together to keep this project a positive space to work together.
+Let’s work together to keep this project a positive space.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# CONTRIBUTING
+
+Thank you for your interest in contributing to this project! We welcome contributions from everyone.
+
+## How to Contribute
+
+### For External Contributors (Non-RMI Members)
+
+- **Fork the repository** and create your branch from `main`.
+- Make your changes.
+- Open a PR from your fork and request review **only when your changes are ready**.
+- A maintainer will review and merge your PR as appropriate.
+
+### For RMI Organization Members
+
+- Create a branch directly in the repository.
+- Open a PR into `main` when ready.
+- After your PR is approved, **merge it yourself**.
+
+## Commit Message Guidelines
+
+- Every pull request (PR) must contain at least one [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/). Not all commits in the PR need to be conventional, but at least one is required.
+
+## General Guidelines
+
+- Be respectful and follow our [Code of Conduct](./CODE_OF_CONDUCT.md).
+- Write clear, concise commit messages.
+- Add tests and documentation as appropriate.
+- If you have questions, open an issue or start a discussion.
+
+Thank you for helping make this project better!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,7 @@ Thank you for your interest in contributing to this project! We welcome contribu
 - Create a branch directly in the repository.
 - Open a PR into `main` when ready.
 - After your PR is approved, **merge it yourself**.
+  - This workflow allows you to get a "conceptual" review on design and have a discussion, or to tidy up a last minute change prior to merging (updates dismiss reviews and require re-approval).
 
 ## Commit Message Guidelines
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,9 @@ Thank you for your interest in contributing to this project! We welcome contribu
 
 ## Commit Message Guidelines
 
-- Every pull request (PR) must contain at least one [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/). Not all commits in the PR need to be conventional, but at least one is required.
+- Every pull request (PR) must contain at least one [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/).
+  - Not all commits in the PR need to be conventional, but at least one is required.
+  - This repo has an action set up to comment on PRs with the expected change log, and if there are no conventional commits, that comment will say so.
 
 ## General Guidelines
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Thank you for your interest in contributing to this project! We welcome contribu
 - Open a PR from your fork and request review **only when your changes are ready**.
 - A maintainer will review and merge your PR as appropriate.
 
-### For RMI Organization Members
+### For RMI Organization Members (`write` privileges)
 
 - Create a branch directly in the repository.
 - Open a PR into `main` when ready.


### PR DESCRIPTION
Added `CODE_OF_CONDUCT.md` to outline expectations for respectful and inclusive participation.
Added `CONTRIBUTING.md` to provide guidelines for external contributors and RMI members. Also included general guidance to include at least 1 conventional commit per PR.

Closes #320 