### PR TITLE
Close swa

### DIFF
--- a/.github/workflows/azure-static-web-apps-close.yml
+++ b/.github/workflows/azure-static-web-apps-close.yml
@@ -1,0 +1,22 @@
+---
+on:
+  workflow_call:
+
+name: Azure Static Web Apps Close Environment
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  close_pull_request_job:
+    runs-on: ubuntu-latest
+    name: Close Pull Request Job
+    steps:
+      - name: Close Pull Request
+        id: closepullrequest
+        uses: Azure/static-web-apps-deploy@v1
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_PROUD_GLACIER_0F640931E }}
+          action: "close"
+          skip_deploy_on_missing_secrets: ${{ github.actor == 'dependabot[bot]' }}

--- a/.github/workflows/azure-static-web-apps-deploy.yml
+++ b/.github/workflows/azure-static-web-apps-deploy.yml
@@ -42,16 +42,3 @@ jobs:
           skip_app_build: true # Skipps app build (read from extracted tarball)
           skip_api_build: true # Skips API (functions) build step
           production_branch: "production" # all other branches are preview builds
-
-  close_pull_request_job:
-    if: github.event_name == 'pull_request' && github.event.action == 'closed'
-    runs-on: ubuntu-latest
-    name: Close Pull Request Job
-    steps:
-      - name: Close Pull Request
-        id: closepullrequest
-        uses: Azure/static-web-apps-deploy@v1
-        with:
-          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_PROUD_GLACIER_0F640931E }}
-          action: "close"
-          skip_deploy_on_missing_secrets: ${{ github.actor == 'dependabot[bot]' }}

--- a/.github/workflows/node-pr_close.yml
+++ b/.github/workflows/node-pr_close.yml
@@ -1,0 +1,13 @@
+---
+on:
+  pull_request:
+    types:
+      - closed
+
+name: Node Package Checks
+
+jobs:
+  close-swa:
+    name: "Close SWA environment"
+    uses: ./.github/workflows/azure-static-web-apps-close.yml
+    secrets: inherit

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -1,11 +1,6 @@
 ---
 on:
   pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - closed
     branches:
       - main
       - production
@@ -23,32 +18,26 @@ concurrency:
 jobs:
   linting:
     name: "Linting"
-    if: ${{ !( github.event_name == 'pull_request' && github.event.action == 'closed' ) }}
     uses: ./.github/workflows/node-lint.yml
 
   formatting:
     name: "Formatting"
-    if: ${{ !( github.event_name == 'pull_request' && github.event.action == 'closed' ) }}
     uses: ./.github/workflows/node-prettier.yml
 
   unit-test:
     name: "Unit Tests"
-    if: ${{ !( github.event_name == 'pull_request' && github.event.action == 'closed' ) }}
     uses: ./.github/workflows/node-test.yml
 
   json-schema:
     name: "JSON Schema Validation"
-    if: ${{ !( github.event_name == 'pull_request' && github.event.action == 'closed' ) }}
     uses: ./.github/workflows/node-json-schema.yml
 
   types:
     name: "JSON Schema <-> Types Validation"
-    if: ${{ !( github.event_name == 'pull_request' && github.event.action == 'closed' ) }}
     uses: ./.github/workflows/node-types.yml
 
   build-release:
     name: "Build and Release"
-    if: ${{ !( github.event_name == 'pull_request' && github.event.action == 'closed' ) }}
     uses: ./.github/workflows/node-build_release.yml
     secrets: inherit
 
@@ -61,5 +50,4 @@ jobs:
 
   scan:
     name: "Check for forbidden patterns"
-    if: ${{ !( github.event_name == 'pull_request' && github.event.action == 'closed' ) }}
     uses: ./.github/workflows/admin-forbidden-patterns.yml


### PR DESCRIPTION
Resolves an issue that's crept into our SWA deployment workflow, in the batch of changes that was around 3 weeks ago:

My working assumption here is that when I changed the conditions to run the `deploy` job:

```yml
  build-release:
    name: "Build and Release"
    if: ${{ !( github.event_name == 'pull_request' && github.event.action == 'closed' ) }}
    uses: ./.github/workflows/node-build_release.yml
    secrets: inherit

  deploy:
    name: "Deploy to SWA"
    if: ${{ needs.build-release.outputs.has_artifact }}
    needs: [build-release]
    uses: ./.github/workflows/azure-static-web-apps-deploy.yml
    secrets: inherit
```

we run into the situation that on a `pr_close` event, the `build-release` job doesn't run (`if` condition), so then `deploy` can't either (`needs` dependency).

Solving this by moving all of the "PR closing" logic out of the the "PR Opening/updating" workflow. This could also be solved by changing the `if` condition on the `deploy` action, but this solution also nicely gets rid of the `"one job skipped" in the CI summary (for skipping the close environment step).