### PR TITLE
Fix: rulesets check

### DIFF
--- a/.github/rulesets/gitflow-main.json
+++ b/.github/rulesets/gitflow-main.json
@@ -26,6 +26,7 @@
       "parameters": {
         "required_approving_review_count": 1,
         "dismiss_stale_reviews_on_push": true,
+        "required_reviewers": [],
         "require_code_owner_review": true,
         "require_last_push_approval": true,
         "required_review_thread_resolution": false,

--- a/.github/rulesets/gitflow-next-pr.json
+++ b/.github/rulesets/gitflow-next-pr.json
@@ -22,6 +22,7 @@
       "parameters": {
         "required_approving_review_count": 1,
         "dismiss_stale_reviews_on_push": true,
+        "required_reviewers": [],
         "require_code_owner_review": true,
         "require_last_push_approval": true,
         "required_review_thread_resolution": true,

--- a/.github/rulesets/gitflow-production.json
+++ b/.github/rulesets/gitflow-production.json
@@ -26,6 +26,7 @@
       "parameters": {
         "required_approving_review_count": 2,
         "dismiss_stale_reviews_on_push": true,
+        "required_reviewers": [],
         "require_code_owner_review": true,
         "require_last_push_approval": true,
         "required_review_thread_resolution": true,

--- a/.github/workflows/admin-check_rulesets.yml
+++ b/.github/workflows/admin-check_rulesets.yml
@@ -1,8 +1,10 @@
 ---
 on:
   pull_request:
-    paths:
-      - ".github/rulesets/**"
+    branches:
+      - main
+      - production
+      - next
   push:
     branches:
       - main


### PR DESCRIPTION
GH made an update to the `rulesets` JSON format (adding `required_reviewers` in the PR requirements)

Adding an empty `required_reviewers` array to rulesets, to match format
with GH ruleset update.

Additionally, change CI trigger so check runs on most PRs, rather than just ones that touch the `.github/rulesets` directory.