### PR TITLE
Swa config in tarball

### DIFF
--- a/.github/workflows/azure-static-web-apps-deploy.yml
+++ b/.github/workflows/azure-static-web-apps-deploy.yml
@@ -42,3 +42,4 @@ jobs:
           skip_app_build: true # Skipps app build (read from extracted tarball)
           skip_api_build: true # Skips API (functions) build step
           production_branch: "production" # all other branches are preview builds
+          config_file_location: "dist_extracted"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "json:check:testdata": "npx ts-node --esm scripts/schema-check-files.ts testdata/valid",
     "json:generate:types": "npx ts-node --esm scripts/generate-types.ts && prettier --write \"src/types/*.d.ts\"",
     "docs:jsonSchema": "scripts/generate-schema-docs.sh",
-    "prepare:tarball": "npm ci && npm run build && tar -czf dist.tgz -C dist .",
+    "prepare:tarball": "npm ci && npm run build && cp staticwebapp.config.json dist && tar -czf dist.tgz -C dist .",
     "build:timeseries": "npx ts-node --esm scripts/build-timeseries-files.ts && prettier --write \"src/data/index.gen.ts\"",
     "prebuild": "npm run build:timeseries",
     "predev": "npm run build:timeseries"


### PR DESCRIPTION
Supersedes #510 
Closes #492 

Adds the staticwebapp.config.json to the build tarball (`package.json`), and tells AzSWA to look for the file in that directory when deploying (workflow file)

Preferable to cloning the repo when deploying in that it keeps the integrity of the built artifact (the config file is known to be from the same revision as the site that's deploying), avoiding any possible drift between the artifact and the related branch (multiple pushes in quick succession). 