### PR TITLE
fix(types): add schema property to TimeseriesIndex type

### DIFF
--- a/scripts/build-timeseries-files.ts
+++ b/scripts/build-timeseries-files.ts
@@ -52,6 +52,10 @@ type TimeseriesIndex = {
       summary?: unknown;
     }
   >;
+  schema: {
+    version: number;
+    generatedAt: string;
+  };
 };
 
 const ROOT = process.cwd();
@@ -260,6 +264,10 @@ async function main() {
   const out: TimeseriesIndex = {
     byPathway,
     byDataset,
+    schema: {
+      version: 1,
+      generatedAt: new Date().toISOString(),
+    },
   };
 
   // -------------------------------

--- a/src/data/index.gen.ts
+++ b/src/data/index.gen.ts
@@ -50,5 +50,9 @@ export const index: TimeseriesIndex = {
       path: "/data/asean-centre-for-energy/BAS-2024_timeseries.csv",
     },
   },
+  schema: {
+    version: 1,
+    generatedAt: "2025-11-05T14:23:08.770Z",
+  },
 } as const;
 export default index;

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,7 +1,9 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "lib": ["ES2022"],
+    "lib": [
+      "ES2022"
+    ],
     "module": "ESNext",
     "skipLibCheck": true,
     "moduleResolution": "bundler",
@@ -16,6 +18,7 @@
     "vitest.config.ts",
     "postcss.config.ts",
     "tailwind.config.ts",
-    "src/utils/*.ts"
+    "src/utils/*.ts",
+    "src/data/index.gen.ts"
   ]
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,9 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "lib": [
-      "ES2022"
-    ],
+    "lib": ["ES2022"],
     "module": "ESNext",
     "skipLibCheck": true,
     "moduleResolution": "bundler",


### PR DESCRIPTION
- Add `schema` type definition with `version` and `generatedAt` fields
- Implement schema property in output object of `build-timeseries-files.ts`
- Add `schema` property to generated `index.gen.ts` output

Also adds ` "src/data/index.gen.ts"` to `tsconfig.node.json`, since `index.gen.ts` is used in `src/utils/timeseriesIndex.ts` (which itself is in `src/utils/*`).

Relates to #514 