### PR TITLE
feat(ui): update background from white to gray

### DIFF
--- a/src/components/SearchBox.tsx
+++ b/src/components/SearchBox.tsx
@@ -24,11 +24,10 @@ const SearchBox: React.FC<SearchBoxProps> = ({
 
   return (
     <div
-      className={`flex items-center w-full max-w-169 rounded-md border transition-all duration-200 bg-white ${
-        isFocused
+      className={`flex items-center w-full max-w-169 rounded-md border transition-all duration-200 bg-white ${isFocused
           ? "border-energy-400 ring-2 ring-energy-100"
           : "border-neutral-300"
-      }`}
+        }`}
     >
       <div className="pl-3 text-gray-400">
         <Search size={20} />

--- a/src/components/SearchBox.tsx
+++ b/src/components/SearchBox.tsx
@@ -24,10 +24,11 @@ const SearchBox: React.FC<SearchBoxProps> = ({
 
   return (
     <div
-      className={`flex items-center w-full max-w-169 rounded-md border transition-all duration-200 bg-white ${isFocused
+      className={`flex items-center w-full max-w-169 rounded-md border transition-all duration-200 bg-white ${
+        isFocused
           ? "border-energy-400 ring-2 ring-energy-100"
           : "border-neutral-300"
-        }`}
+      }`}
     >
       <div className="pl-3 text-gray-400">
         <Search size={20} />

--- a/src/components/SearchSection.tsx
+++ b/src/components/SearchSection.tsx
@@ -104,7 +104,7 @@ const SearchSection: React.FC<SearchSectionProps> = ({
       : filters.modelTempIncrease != null);
 
   return (
-    <div className="bg-white">
+    <div className="bg-gray-50">
       <div className="mb-4 pt-8">
         <SearchBox
           value={filters.searchTerm}

--- a/src/pages/PathwaySearch.tsx
+++ b/src/pages/PathwaySearch.tsx
@@ -43,7 +43,7 @@ const PathwaySearch: React.FC = () => {
         filters.pathwayType !== prevFiltersRef.current.pathwayType ||
         filters.modelYearNetzero !== prevFiltersRef.current.modelYearNetzero ||
         filters.modelTempIncrease !==
-          prevFiltersRef.current.modelTempIncrease ||
+        prevFiltersRef.current.modelTempIncrease ||
         filters.geography !== prevFiltersRef.current.geography ||
         filters.sector !== prevFiltersRef.current.sector ||
         filters.metric !== prevFiltersRef.current.metric;
@@ -125,7 +125,7 @@ const PathwaySearch: React.FC = () => {
       </section>
       <div
         ref={searchSectionRef}
-        className={`sticky rounded-lg top-0 z-10 bg-white inset-x-0 transition-shadow duration-200 ${isSticky ? "shadow-md" : ""}`}
+        className={`sticky rounded-lg top-0 z-10 bg-gray-50 inset-x-0 transition-shadow duration-200 ${isSticky ? "shadow-md" : ""}`}
         style={{ margin: "0 calc(-50vw + 50%)" }}
       >
         <div className="container mx-auto px-4 py-2">

--- a/src/pages/PathwaySearch.tsx
+++ b/src/pages/PathwaySearch.tsx
@@ -43,7 +43,7 @@ const PathwaySearch: React.FC = () => {
         filters.pathwayType !== prevFiltersRef.current.pathwayType ||
         filters.modelYearNetzero !== prevFiltersRef.current.modelYearNetzero ||
         filters.modelTempIncrease !==
-        prevFiltersRef.current.modelTempIncrease ||
+          prevFiltersRef.current.modelTempIncrease ||
         filters.geography !== prevFiltersRef.current.geography ||
         filters.sector !== prevFiltersRef.current.sector ||
         filters.metric !== prevFiltersRef.current.metric;


### PR DESCRIPTION
Previously, the search bar was appearing "white" and the rest of the website had an off gray background:
<img width="1440" height="423" alt="Screenshot 2025-11-05 at 17 38 42" src="https://github.com/user-attachments/assets/cf11b79f-68c0-4b90-a782-2bb5896a9429" />

This PR aligns it on off-gray, to give a more unified appearance:
<img width="1440" height="522" alt="Screenshot 2025-11-05 at 17 39 28" src="https://github.com/user-attachments/assets/1c2b4cc8-76c8-4ca4-975f-cc4c2a0754c4" />

