### PR TITLE
Fix/typecheck index gen

### DIFF
--- a/scripts/build-timeseries-files.ts
+++ b/scripts/build-timeseries-files.ts
@@ -12,7 +12,7 @@
 //   - label      := label | name
 //
 // Output:
-//   - Writes src/data/index.json with { byPathway, byDataset, schema }.
+//   - Writes src/data/index.json with { byPathway, byDataset }.
 
 import { promises as fs } from "node:fs";
 import * as path from "node:path";
@@ -414,7 +414,6 @@ async function main() {
 export type TimeseriesIndex = {
   byPathway: Record<string, TimeseriesIndexItem[]>;
   byDataset: Record<string, { datasetId: string; pathwayIds: string[]; label?: string; path: string; summary?: unknown }>;
-  schema: { version: number; generatedAt: string };
 };
 export const index: TimeseriesIndex = ${JSON.stringify(out, null, 2)} as const;
 export default index;

--- a/src/data/index.gen.ts
+++ b/src/data/index.gen.ts
@@ -18,7 +18,6 @@ export type TimeseriesIndex = {
       summary?: unknown;
     }
   >;
-  schema: { version: number; generatedAt: string };
 };
 export const index: TimeseriesIndex = {
   byPathway: {

--- a/src/utils/timeseriesIndex.test.ts
+++ b/src/utils/timeseriesIndex.test.ts
@@ -25,7 +25,6 @@ describe("timeseriesIndex helpers", () => {
           path: "/data/BAS-2024_timeseries.json",
         },
       },
-      schema: { version: 1, generatedAt: new Date().toISOString() },
     };
 
     expect(datasetsForPathway(idx, "ACE-BAS-2024")).toEqual([

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -8,7 +8,9 @@
     "isolatedModules": true,
     "noEmit": true,
     "strict": true,
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "composite": true,
+    "tsBuildInfoFile": ".tsbuildcache/node.tsbuildinfo"
   },
   "include": [
     "vite.config.ts",
@@ -16,6 +18,7 @@
     "vitest.config.ts",
     "postcss.config.ts",
     "tailwind.config.ts",
-    "src/utils/*.ts"
+    "src/utils/*.ts",
+    "src/data/index.gen.ts"
   ]
 }


### PR DESCRIPTION
Supersedes https://github.com/RMI/pbtar/pull/521

addresses typecheck issues without adding the (noisy on infrequent update) schema to the file