### PR TITLE
fix: remove references to old schema fields

### DIFF
--- a/src/pages/PathwayDetailPage.tsx
+++ b/src/pages/PathwayDetailPage.tsx
@@ -160,11 +160,12 @@ const PathwayDetailPage: React.FC = () => {
 
           <div className="flex flex-col sm:flex-row sm:justify-between text-sm">
             <p className="mb-1 sm:mb-0">
-              <span className="text-white">Publisher:</span> {pathway.publisher}
+              <span className="text-white">Publisher:</span>{" "}
+              {pathway.publication.publisher.full}
             </p>
             <p>
               <span className="text-white">Published:</span>{" "}
-              {pathway.publicationYear}
+              {pathway.publication.year}
             </p>
           </div>
         </div>

--- a/src/utils/searchUtils.ts
+++ b/src/utils/searchUtils.ts
@@ -254,8 +254,8 @@ export const filterPathways = (
         ...pathway.geography.map((s) => geographyLabel(s)),
         ...pathway.sectors.map((s) => s.name),
         ...pathway.metric,
-        pathway.publisher,
-        pathway.publicationYear,
+        pathway.publication.publisher.full,
+        pathway.publication.year,
       ];
 
       return searchFields.some((field) =>

--- a/src/utils/searchUtils.ts
+++ b/src/utils/searchUtils.ts
@@ -203,15 +203,15 @@ export const filterPathways = (
       const ok =
         mode === "ALL"
           ? matchesOptionalFacetAll(
-              normalizedSelected,
-              pathway.geography ?? [],
-              (g) => norm(g),
-            )
+            normalizedSelected,
+            pathway.geography ?? [],
+            (g) => norm(g),
+          )
           : matchesOptionalFacetAny(
-              normalizedSelected,
-              pathway.geography ?? [],
-              (g) => norm(g),
-            );
+            normalizedSelected,
+            pathway.geography ?? [],
+            (g) => norm(g),
+          );
       if (!ok) return false;
     }
 
@@ -255,6 +255,7 @@ export const filterPathways = (
         ...pathway.sectors.map((s) => s.name),
         ...pathway.metric,
         pathway.publication.publisher.full,
+        pathway.publication.publisher.short,
         pathway.publication.year,
       ];
 

--- a/src/utils/searchUtils.ts
+++ b/src/utils/searchUtils.ts
@@ -203,15 +203,15 @@ export const filterPathways = (
       const ok =
         mode === "ALL"
           ? matchesOptionalFacetAll(
-            normalizedSelected,
-            pathway.geography ?? [],
-            (g) => norm(g),
-          )
+              normalizedSelected,
+              pathway.geography ?? [],
+              (g) => norm(g),
+            )
           : matchesOptionalFacetAny(
-            normalizedSelected,
-            pathway.geography ?? [],
-            (g) => norm(g),
-          );
+              normalizedSelected,
+              pathway.geography ?? [],
+              (g) => norm(g),
+            );
       if (!ok) return false;
     }
 


### PR DESCRIPTION
This handles the immediate bug of "Publisher:" and "Published:" values being empty on the Scenario Details page.
The broader challenge of enabling type-checking and dealing with the root of this problem more holistically by handling all `typecheck` failures is being handled concurrently (see #514 and related PRs).

Closes #511 