### PR TITLE
Refactor/metadata name label

### DIFF
--- a/public/schema/pathwayMetadata.v1.html
+++ b/public/schema/pathwayMetadata.v1.html
@@ -263,16 +263,189 @@
                 >name</a
               >
             </div>
-            <span class="badge badge-dark value-type">Type: string</span><br />
+            <h4>Label</h4>
+            <span class="badge badge-dark value-type">Type: object</span><br />
             <span class="description"><p>Name of the pathway.</p> </span>
 
-            <p>
-              <span
-                class="badge badge-light restriction max-length-restriction"
-                id="name_maxLength"
-                >Must be at most <code>100</code> characters long</span
-              >
-            </p>
+            <span class="badge badge-info no-additional"
+              >No Additional Properties</span
+            >
+
+            <div
+              class="accordion"
+              id="accordionname_full"
+            >
+              <div class="card">
+                <div
+                  class="card-header"
+                  id="headingname_full"
+                >
+                  <h2 class="mb-0">
+                    <button
+                      class="btn btn-link property-name-button"
+                      type="button"
+                      data-toggle="collapse"
+                      data-target="#name_full"
+                      aria-expanded=""
+                      aria-controls="name_full"
+                      onclick="setAnchor('#name_full')"
+                    >
+                      <span class="property-name">full</span>
+                      <span class="badge badge-warning required-property"
+                        >Required</span
+                      >
+                    </button>
+                  </h2>
+                </div>
+
+                <div
+                  id="name_full"
+                  class="collapse property-definition-div"
+                  aria-labelledby="headingname_full"
+                  data-parent="#accordionname_full"
+                >
+                  <div class="card-body pl-5">
+                    <div class="breadcrumbs">
+                      root
+                      <svg
+                        width="1em"
+                        height="1em"
+                        viewBox="0 0 16 16"
+                        class="bi bi-arrow-right-short"
+                        fill="currentColor"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          fill-rule="evenodd"
+                          d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+                        />
+                      </svg>
+                      <a
+                        href="#name"
+                        onclick="anchorLink('name')"
+                        >name</a
+                      >
+                      <svg
+                        width="1em"
+                        height="1em"
+                        viewBox="0 0 16 16"
+                        class="bi bi-arrow-right-short"
+                        fill="currentColor"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          fill-rule="evenodd"
+                          d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+                        />
+                      </svg>
+                      <a
+                        href="#name_full"
+                        onclick="anchorLink('name_full')"
+                        >full</a
+                      >
+                    </div>
+                    <span class="badge badge-dark value-type">Type: string</span
+                    ><br />
+                    <span class="description"><p>Full name or label</p> </span>
+
+                    <p>
+                      <span
+                        class="badge badge-light restriction max-length-restriction"
+                        id="name_full_maxLength"
+                        >Must be at most <code>200</code> characters long</span
+                      >
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="accordion"
+              id="accordionname_short"
+            >
+              <div class="card">
+                <div
+                  class="card-header"
+                  id="headingname_short"
+                >
+                  <h2 class="mb-0">
+                    <button
+                      class="btn btn-link property-name-button"
+                      type="button"
+                      data-toggle="collapse"
+                      data-target="#name_short"
+                      aria-expanded=""
+                      aria-controls="name_short"
+                      onclick="setAnchor('#name_short')"
+                    >
+                      <span class="property-name">short</span>
+                    </button>
+                  </h2>
+                </div>
+
+                <div
+                  id="name_short"
+                  class="collapse property-definition-div"
+                  aria-labelledby="headingname_short"
+                  data-parent="#accordionname_short"
+                >
+                  <div class="card-body pl-5">
+                    <div class="breadcrumbs">
+                      root
+                      <svg
+                        width="1em"
+                        height="1em"
+                        viewBox="0 0 16 16"
+                        class="bi bi-arrow-right-short"
+                        fill="currentColor"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          fill-rule="evenodd"
+                          d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+                        />
+                      </svg>
+                      <a
+                        href="#name"
+                        onclick="anchorLink('name')"
+                        >name</a
+                      >
+                      <svg
+                        width="1em"
+                        height="1em"
+                        viewBox="0 0 16 16"
+                        class="bi bi-arrow-right-short"
+                        fill="currentColor"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          fill-rule="evenodd"
+                          d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+                        />
+                      </svg>
+                      <a
+                        href="#name_short"
+                        onclick="anchorLink('name_short')"
+                        >short</a
+                      >
+                    </div>
+                    <span class="badge badge-dark value-type">Type: string</span
+                    ><br />
+                    <span class="description"
+                      ><p>Short name, acronym, or abbreviation</p>
+                    </span>
+
+                    <p>
+                      <span
+                        class="badge badge-light restriction max-length-restriction"
+                        id="name_short_maxLength"
+                        >Must be at most <code>20</code> characters long</span
+                      >
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -503,22 +676,22 @@
 
                     <div
                       class="accordion"
-                      id="accordionpublication_title_full"
+                      id="accordionname_full"
                     >
                       <div class="card">
                         <div
                           class="card-header"
-                          id="headingpublication_title_full"
+                          id="headingname_full"
                         >
                           <h2 class="mb-0">
                             <button
                               class="btn btn-link property-name-button"
                               type="button"
                               data-toggle="collapse"
-                              data-target="#publication_title_full"
+                              data-target="#name_full"
                               aria-expanded=""
-                              aria-controls="publication_title_full"
-                              onclick="setAnchor('#publication_title_full')"
+                              aria-controls="name_full"
+                              onclick="setAnchor('#name_full')"
                             >
                               <span class="property-name">full</span>
                               <span
@@ -530,10 +703,10 @@
                         </div>
 
                         <div
-                          id="publication_title_full"
+                          id="name_full"
                           class="collapse property-definition-div"
-                          aria-labelledby="headingpublication_title_full"
-                          data-parent="#accordionpublication_title_full"
+                          aria-labelledby="headingname_full"
+                          data-parent="#accordionname_full"
                         >
                           <div class="card-body pl-5">
                             <div class="breadcrumbs">
@@ -552,9 +725,9 @@
                                 />
                               </svg>
                               <a
-                                href="#publication"
-                                onclick="anchorLink('publication')"
-                                >publication</a
+                                href="#name"
+                                onclick="anchorLink('name')"
+                                >name</a
                               >
                               <svg
                                 width="1em"
@@ -570,26 +743,8 @@
                                 />
                               </svg>
                               <a
-                                href="#publication_title"
-                                onclick="anchorLink('publication_title')"
-                                >title</a
-                              >
-                              <svg
-                                width="1em"
-                                height="1em"
-                                viewBox="0 0 16 16"
-                                class="bi bi-arrow-right-short"
-                                fill="currentColor"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  fill-rule="evenodd"
-                                  d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
-                                />
-                              </svg>
-                              <a
-                                href="#publication_title_full"
-                                onclick="anchorLink('publication_title_full')"
+                                href="#name_full"
+                                onclick="anchorLink('name_full')"
                                 >full</a
                               >
                             </div>
@@ -603,7 +758,7 @@
                             <p>
                               <span
                                 class="badge badge-light restriction max-length-restriction"
-                                id="publication_title_full_maxLength"
+                                id="name_full_maxLength"
                                 >Must be at most <code>200</code> characters
                                 long</span
                               >
@@ -614,22 +769,22 @@
                     </div>
                     <div
                       class="accordion"
-                      id="accordionpublication_title_short"
+                      id="accordionname_short"
                     >
                       <div class="card">
                         <div
                           class="card-header"
-                          id="headingpublication_title_short"
+                          id="headingname_short"
                         >
                           <h2 class="mb-0">
                             <button
                               class="btn btn-link property-name-button"
                               type="button"
                               data-toggle="collapse"
-                              data-target="#publication_title_short"
+                              data-target="#name_short"
                               aria-expanded=""
-                              aria-controls="publication_title_short"
-                              onclick="setAnchor('#publication_title_short')"
+                              aria-controls="name_short"
+                              onclick="setAnchor('#name_short')"
                             >
                               <span class="property-name">short</span>
                             </button>
@@ -637,10 +792,10 @@
                         </div>
 
                         <div
-                          id="publication_title_short"
+                          id="name_short"
                           class="collapse property-definition-div"
-                          aria-labelledby="headingpublication_title_short"
-                          data-parent="#accordionpublication_title_short"
+                          aria-labelledby="headingname_short"
+                          data-parent="#accordionname_short"
                         >
                           <div class="card-body pl-5">
                             <div class="breadcrumbs">
@@ -659,9 +814,9 @@
                                 />
                               </svg>
                               <a
-                                href="#publication"
-                                onclick="anchorLink('publication')"
-                                >publication</a
+                                href="#name"
+                                onclick="anchorLink('name')"
+                                >name</a
                               >
                               <svg
                                 width="1em"
@@ -677,26 +832,8 @@
                                 />
                               </svg>
                               <a
-                                href="#publication_title"
-                                onclick="anchorLink('publication_title')"
-                                >title</a
-                              >
-                              <svg
-                                width="1em"
-                                height="1em"
-                                viewBox="0 0 16 16"
-                                class="bi bi-arrow-right-short"
-                                fill="currentColor"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  fill-rule="evenodd"
-                                  d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
-                                />
-                              </svg>
-                              <a
-                                href="#publication_title_short"
-                                onclick="anchorLink('publication_title_short')"
+                                href="#name_short"
+                                onclick="anchorLink('name_short')"
                                 >short</a
                               >
                             </div>
@@ -710,7 +847,7 @@
                             <p>
                               <span
                                 class="badge badge-light restriction max-length-restriction"
-                                id="publication_title_short_maxLength"
+                                id="name_short_maxLength"
                                 >Must be at most <code>20</code> characters
                                 long</span
                               >
@@ -1067,22 +1204,22 @@
 
                     <div
                       class="accordion"
-                      id="accordionpublication_title_full"
+                      id="accordionname_full"
                     >
                       <div class="card">
                         <div
                           class="card-header"
-                          id="headingpublication_title_full"
+                          id="headingname_full"
                         >
                           <h2 class="mb-0">
                             <button
                               class="btn btn-link property-name-button"
                               type="button"
                               data-toggle="collapse"
-                              data-target="#publication_title_full"
+                              data-target="#name_full"
                               aria-expanded=""
-                              aria-controls="publication_title_full"
-                              onclick="setAnchor('#publication_title_full')"
+                              aria-controls="name_full"
+                              onclick="setAnchor('#name_full')"
                             >
                               <span class="property-name">full</span>
                               <span
@@ -1094,10 +1231,10 @@
                         </div>
 
                         <div
-                          id="publication_title_full"
+                          id="name_full"
                           class="collapse property-definition-div"
-                          aria-labelledby="headingpublication_title_full"
-                          data-parent="#accordionpublication_title_full"
+                          aria-labelledby="headingname_full"
+                          data-parent="#accordionname_full"
                         >
                           <div class="card-body pl-5">
                             <div class="breadcrumbs">
@@ -1116,9 +1253,9 @@
                                 />
                               </svg>
                               <a
-                                href="#publication"
-                                onclick="anchorLink('publication')"
-                                >publication</a
+                                href="#name"
+                                onclick="anchorLink('name')"
+                                >name</a
                               >
                               <svg
                                 width="1em"
@@ -1134,26 +1271,8 @@
                                 />
                               </svg>
                               <a
-                                href="#publication_title"
-                                onclick="anchorLink('publication_title')"
-                                >title</a
-                              >
-                              <svg
-                                width="1em"
-                                height="1em"
-                                viewBox="0 0 16 16"
-                                class="bi bi-arrow-right-short"
-                                fill="currentColor"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  fill-rule="evenodd"
-                                  d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
-                                />
-                              </svg>
-                              <a
-                                href="#publication_title_full"
-                                onclick="anchorLink('publication_title_full')"
+                                href="#name_full"
+                                onclick="anchorLink('name_full')"
                                 >full</a
                               >
                             </div>
@@ -1167,7 +1286,7 @@
                             <p>
                               <span
                                 class="badge badge-light restriction max-length-restriction"
-                                id="publication_title_full_maxLength"
+                                id="name_full_maxLength"
                                 >Must be at most <code>200</code> characters
                                 long</span
                               >
@@ -1178,22 +1297,22 @@
                     </div>
                     <div
                       class="accordion"
-                      id="accordionpublication_title_short"
+                      id="accordionname_short"
                     >
                       <div class="card">
                         <div
                           class="card-header"
-                          id="headingpublication_title_short"
+                          id="headingname_short"
                         >
                           <h2 class="mb-0">
                             <button
                               class="btn btn-link property-name-button"
                               type="button"
                               data-toggle="collapse"
-                              data-target="#publication_title_short"
+                              data-target="#name_short"
                               aria-expanded=""
-                              aria-controls="publication_title_short"
-                              onclick="setAnchor('#publication_title_short')"
+                              aria-controls="name_short"
+                              onclick="setAnchor('#name_short')"
                             >
                               <span class="property-name">short</span>
                             </button>
@@ -1201,10 +1320,10 @@
                         </div>
 
                         <div
-                          id="publication_title_short"
+                          id="name_short"
                           class="collapse property-definition-div"
-                          aria-labelledby="headingpublication_title_short"
-                          data-parent="#accordionpublication_title_short"
+                          aria-labelledby="headingname_short"
+                          data-parent="#accordionname_short"
                         >
                           <div class="card-body pl-5">
                             <div class="breadcrumbs">
@@ -1223,9 +1342,9 @@
                                 />
                               </svg>
                               <a
-                                href="#publication"
-                                onclick="anchorLink('publication')"
-                                >publication</a
+                                href="#name"
+                                onclick="anchorLink('name')"
+                                >name</a
                               >
                               <svg
                                 width="1em"
@@ -1241,26 +1360,8 @@
                                 />
                               </svg>
                               <a
-                                href="#publication_title"
-                                onclick="anchorLink('publication_title')"
-                                >title</a
-                              >
-                              <svg
-                                width="1em"
-                                height="1em"
-                                viewBox="0 0 16 16"
-                                class="bi bi-arrow-right-short"
-                                fill="currentColor"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  fill-rule="evenodd"
-                                  d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
-                                />
-                              </svg>
-                              <a
-                                href="#publication_title_short"
-                                onclick="anchorLink('publication_title_short')"
+                                href="#name_short"
+                                onclick="anchorLink('name_short')"
                                 >short</a
                               >
                             </div>
@@ -1274,7 +1375,7 @@
                             <p>
                               <span
                                 class="badge badge-light restriction max-length-restriction"
-                                id="publication_title_short_maxLength"
+                                id="name_short_maxLength"
                                 >Must be at most <code>20</code> characters
                                 long</span
                               >

--- a/src/components/PathwayCard.test.tsx
+++ b/src/components/PathwayCard.test.tsx
@@ -65,7 +65,11 @@ describe("PathwayCard component", () => {
   it("renders the pathway name and description", () => {
     renderPathwayCard();
 
-    expect(screen.getByText(mockPathway.name.short)).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        mockPathway.name.full + " (" + mockPathway.name.short + ")",
+      ),
+    ).toBeInTheDocument();
     expect(screen.getByText(mockPathway.description)).toBeInTheDocument();
   });
 

--- a/src/components/PathwayCard.test.tsx
+++ b/src/components/PathwayCard.test.tsx
@@ -65,7 +65,7 @@ describe("PathwayCard component", () => {
   it("renders the pathway name and description", () => {
     renderPathwayCard();
 
-    expect(screen.getByText(mockPathway.name)).toBeInTheDocument();
+    expect(screen.getByText(mockPathway.name.short)).toBeInTheDocument();
     expect(screen.getByText(mockPathway.description)).toBeInTheDocument();
   });
 

--- a/src/components/PathwayCard.tsx
+++ b/src/components/PathwayCard.tsx
@@ -114,7 +114,10 @@ const PathwayCard: React.FC<PathwayCardProps> = ({
           <Link to={`/pathway/${pathway.id}`}>
             <h2 className="text-xl font-semibold text-bluespruce mb-2">
               <HighlightedText
-                text={pathway.name.short || pathway.name.full}
+                text={
+                  pathway.name.full +
+                  (pathway.name.short ? ` (${pathway.name.short})` : "")
+                }
                 searchTerm={searchTerm}
               />
             </h2>

--- a/src/components/PathwayCard.tsx
+++ b/src/components/PathwayCard.tsx
@@ -114,7 +114,7 @@ const PathwayCard: React.FC<PathwayCardProps> = ({
           <Link to={`/pathway/${pathway.id}`}>
             <h2 className="text-xl font-semibold text-bluespruce mb-2">
               <HighlightedText
-                text={pathway.name}
+                text={pathway.name.short || pathway.name.full}
                 searchTerm={searchTerm}
               />
             </h2>

--- a/src/data/asean-centre-for-energy/ACE-ATS-2024.json
+++ b/src/data/asean-centre-for-energy/ACE-ATS-2024.json
@@ -14,7 +14,7 @@
       }
     ]
   },
-  "name": "ASEAN Member State Targets Scenario (ATS)",
+  "name": { "full": "ASEAN Member State Targets Scenario", "short": "ATS" },
   "description": "ASEAN-specific pathway exploring impact of unconditional NDCs and existing policies.",
   "geography": ["South East Asia"],
   "pathwayType": "Exploratory",

--- a/src/data/asean-centre-for-energy/ACE-BAS-2024.json
+++ b/src/data/asean-centre-for-energy/ACE-BAS-2024.json
@@ -14,7 +14,7 @@
       }
     ]
   },
-  "name": "Baseline Scenario (BAS)",
+  "name": { "full": "Baseline Scenario", "short": "BAS" },
   "description": "Baseline prediction of historical trends in ASEAN energy systems without policy impacts.",
   "geography": ["South East Asia"],
   "pathwayType": "Predictive",

--- a/src/data/asean-centre-for-energy/ACE-CNS-2024.json
+++ b/src/data/asean-centre-for-energy/ACE-CNS-2024.json
@@ -14,7 +14,7 @@
       }
     ]
   },
-  "name": "Carbon Neutrality Scenario (CNS)",
+  "name": { "full": "Carbon Neutrality Scenario", "short": "CNS" },
   "description": "Pathway for ASEAN to achieve significant CO2 emissions reductions by 2050.",
   "geography": ["South East Asia"],
   "pathwayType": "Normative",

--- a/src/data/asean-centre-for-energy/ACE-RAS-2024.json
+++ b/src/data/asean-centre-for-energy/ACE-RAS-2024.json
@@ -14,7 +14,7 @@
       }
     ]
   },
-  "name": "Regional Aspiration Scenario (RAS)",
+  "name": { "full": "Regional Aspiration Scenario", "short": "RAS" },
   "description": "ASEAN-specific pathway exploring impact of unconditional NDCs and long-term pledges.",
   "geography": ["South East Asia"],
   "pathwayType": "Exploratory",

--- a/src/data/iea/IEA-APS-2024.json
+++ b/src/data/iea/IEA-APS-2024.json
@@ -20,7 +20,7 @@
       }
     ]
   },
-  "name": "Announced Pledges Scenario (APS)",
+  "name": { "full": "Announced Pledges Scenario", "short": "APS" },
   "description": "Countries meet aspirational targets including NDCs and net zero pledges.",
   "geography": [
     "Global",

--- a/src/data/iea/IEA-NZE-2024.json
+++ b/src/data/iea/IEA-NZE-2024.json
@@ -20,7 +20,7 @@
       }
     ]
   },
-  "name": "Net Zero Emissions by 2050 Scenario (NZE)",
+  "name": { "full": "Net Zero Emissions by 2050 Scenario", "short": "NZE" },
   "description": "Normative global 1.5°C aligned pathway that achieves net zero emissions by 2050.",
   "geography": ["Global"],
   "pathwayType": "Normative",

--- a/src/data/iea/IEA-STEPS-2024.json
+++ b/src/data/iea/IEA-STEPS-2024.json
@@ -20,7 +20,7 @@
       }
     ]
   },
-  "name": "Stated Policies Scenario (STEPS)",
+  "name": { "full": "Stated Policies Scenario", "short": "STEPS" },
   "description": "Global projection of current energy system trends and the impact of stated policies.",
   "geography": [
     "Global",

--- a/src/data/jrc/jrc-geco_1_5-2025.json
+++ b/src/data/jrc/jrc-geco_1_5-2025.json
@@ -22,7 +22,7 @@
       }
     ]
   },
-  "name": "1.5°C scenario (1.5°C)",
+  "name": { "full": "1.5°C scenario", "short": "1.5°C" },
   "description": "Global normative pathway limiting warming to 1.5°C, with net zero achieved in 2060.",
   "geography": [
     "Global",

--- a/src/data/jrc/jrc-geco_ndc_lts-2025.json
+++ b/src/data/jrc/jrc-geco_ndc_lts-2025.json
@@ -22,7 +22,10 @@
       }
     ]
   },
-  "name": "Nationally Determined Contributions and Long-Term Strategies (NDC-LTS)",
+  "name": {
+    "full": "Nationally Determined Contributions and Long-Term Strategies",
+    "short": "NDC-LTS"
+  },
   "description": "Exploratory global pathway. All countries achieve NDCs and long-term carbon neutrality pledges.",
   "geography": [
     "Global",

--- a/src/data/jrc/jrc-geco_reference-2025.json
+++ b/src/data/jrc/jrc-geco_reference-2025.json
@@ -22,7 +22,7 @@
       }
     ]
   },
-  "name": "Reference Scenario (Reference)",
+  "name": { "full": "Reference Scenario", "short": "Reference" },
   "description": "Global model extrapolating trends under currently legislated policies.",
   "geography": [
     "Global",

--- a/src/data/philippines-department-of-energy/PHDoE-CES1-2023.json
+++ b/src/data/philippines-department-of-energy/PHDoE-CES1-2023.json
@@ -16,7 +16,7 @@
       }
     ]
   },
-  "name": "Clean Energy Scenario 1 (CES 1)",
+  "name": { "full": "Clean Energy Scenario 1", "short": "CES 1" },
   "description": "Philippines pathway following National Renewable Energy Plan with some offshore wind development.",
   "geography": ["PH"],
   "pathwayType": "Direct Policy",

--- a/src/data/philippines-department-of-energy/PHDoE-CES2-2023.json
+++ b/src/data/philippines-department-of-energy/PHDoE-CES2-2023.json
@@ -16,7 +16,7 @@
       }
     ]
   },
-  "name": "Clean Energy Scenario 2 (CES 2)",
+  "name": { "full": "Clean Energy Scenario 2", "short": "CES 2" },
   "description": "Philippines pathway following National Renewable Energy Plan. Significant offshore wind development.",
   "geography": ["PH"],
   "pathwayType": "Direct Policy",

--- a/src/data/philippines-department-of-energy/PHDoE-Reference-2023.json
+++ b/src/data/philippines-department-of-energy/PHDoE-Reference-2023.json
@@ -16,7 +16,7 @@
       }
     ]
   },
-  "name": "Reference Scenario (Reference)",
+  "name": { "full": "Reference Scenario", "short": "Reference" },
   "description": "Continuation of historical trends in the energy system in the Philippines.",
   "geography": ["PH"],
   "pathwayType": "Direct Policy",

--- a/src/data/vn-erea-dea/EREA_DEA-GG-2024.json
+++ b/src/data/vn-erea-dea/EREA_DEA-GG-2024.json
@@ -17,7 +17,7 @@
       }
     ]
   },
-  "name": "Green Growth Scenario (GG)",
+  "name": { "full": "Green Growth Scenario", "short": "GG" },
   "description": "Net-zero pathway with economic shifts toward low-emissions-intensity sectors.",
   "geography": ["VN"],
   "pathwayType": "Normative",

--- a/src/data/vn-erea-dea/EREA_DEA-GT-2024.json
+++ b/src/data/vn-erea-dea/EREA_DEA-GT-2024.json
@@ -17,7 +17,7 @@
       }
     ]
   },
-  "name": "Green Transport Scenario (GT)",
+  "name": { "full": "Green Transport Scenario", "short": "GT" },
   "description": "Net-zero pathway with full implementation of Vietnam's Green Transport Strategy.",
   "geography": ["VN"],
   "pathwayType": "Normative",

--- a/src/data/vn-erea-dea/EREA_DEA-NZ-2024.json
+++ b/src/data/vn-erea-dea/EREA_DEA-NZ-2024.json
@@ -17,7 +17,7 @@
       }
     ]
   },
-  "name": "Net-Zero Scenario (NZ)",
+  "name": { "full": "Net-Zero Scenario", "short": "NZ" },
   "description": "Cost-optimized pathway to achieve net-zero emissions in 2050 with rapid renewables growth.",
   "geography": ["VN"],
   "pathwayType": "Normative",

--- a/src/data/vn-erea-dea/EREA_DEA-NZplus-2024.json
+++ b/src/data/vn-erea-dea/EREA_DEA-NZplus-2024.json
@@ -17,7 +17,7 @@
       }
     ]
   },
-  "name": "Net-Zero+ Scenario (NZ+)",
+  "name": { "full": "Net-Zero+ Scenario", "short": "NZ+" },
   "description": "Ambitious pathway to absolute zero emissions, with significant new technology.",
   "geography": ["VN"],
   "pathwayType": "Normative",

--- a/src/data/vn-erea-dea/EREA_DEA-VN_Baseline-2024.json
+++ b/src/data/vn-erea-dea/EREA_DEA-VN_Baseline-2024.json
@@ -17,7 +17,7 @@
       }
     ]
   },
-  "name": "Baseline Scenario (Baseline)",
+  "name": { "full": "Baseline Scenario", "short": "Baseline" },
   "description": "Business-as-usual baseline pathway for Vietnam's energy sector.",
   "geography": ["VN"],
   "pathwayType": "Predictive",

--- a/src/pages/PathwayDetailPage.tsx
+++ b/src/pages/PathwayDetailPage.tsx
@@ -134,7 +134,8 @@ const PathwayDetailPage: React.FC = () => {
       <div className="bg-white rounded-lg shadow-md overflow-hidden">
         <div className="bg-bluespruce p-6 text-white">
           <h1 className="text-2xl md:text-3xl font-bold mb-2">
-            {pathway.name}
+            {pathway.name.full +
+              (pathway.name.short ? ` (${pathway.name.short})` : "")}
           </h1>
           <p className="text-white mb-4">{pathway.description}</p>
 

--- a/src/pages/PathwaySearch.test.tsx
+++ b/src/pages/PathwaySearch.test.tsx
@@ -13,7 +13,7 @@ vi.mock("../components/PathwayCard", () => ({
       data-testid="pathway-card"
       data-pathway-id={pathway.id}
     >
-      {pathway.name}
+      {pathway.name.short || pathway.name.full}
     </div>
   ),
 }));
@@ -64,7 +64,7 @@ describe("PathwaySearch integration: dropdowns render and filter with 'None'", (
   const fixtures = [
     {
       id: "A",
-      name: "Pathway A (no sectors, no geo, no temp)",
+      name: { full: "Pathway A", short: "no sectors, no geo, no temp" },
       sectors: undefined, // -> Sector "None"
       geography: undefined, // -> Geography "None"
       modelTempIncrease: undefined, // -> Temperature "None"
@@ -74,7 +74,7 @@ describe("PathwaySearch integration: dropdowns render and filter with 'None'", (
     },
     {
       id: "B",
-      name: "Pathway B (Power, Europe, 2°C)",
+      name: { full: "Pathway B", short: "Power, Europe, 2°C" },
       sectors: [{ name: "Power" }],
       geography: ["Europe"],
       modelTempIncrease: "2°C",
@@ -84,7 +84,7 @@ describe("PathwaySearch integration: dropdowns render and filter with 'None'", (
     },
     {
       id: "C",
-      name: "Pathway C (empty sectors[], empty geo[], 1.5°C)",
+      name: { full: "Pathway C", short: "empty sectors[], empty geo[], 1.5°C" },
       sectors: [], // -> Sector "None"
       geography: [], // -> Geography "None"
       modelTempIncrease: "1.5°C",
@@ -94,7 +94,7 @@ describe("PathwaySearch integration: dropdowns render and filter with 'None'", (
     },
     {
       id: "D",
-      name: "Pathway D (Industry, Asia, no temp)",
+      name: { full: "Pathway D", short: "Industry, Asia, no temp" },
       sectors: [{ name: "Industry" }],
       geography: ["Asia"],
       modelTempIncrease: undefined, // -> Temperature "None"
@@ -104,7 +104,7 @@ describe("PathwaySearch integration: dropdowns render and filter with 'None'", (
     },
     {
       id: "E",
-      name: "Pathway E (Power, Europe+Asia, 2°C)",
+      name: { full: "Pathway E", short: "Power, Europe+Asia, 2°C" },
       sectors: [{ name: "Power" }],
       geography: ["Europe", "Asia"],
       modelTempIncrease: "2°C",
@@ -177,13 +177,10 @@ describe("PathwaySearch integration: dropdowns render and filter with 'None'", (
 
     // Only pathways with no sectors: A (undefined), C (empty array)
     expectVisible([
-      "Pathway A (no sectors, no geo, no temp)",
-      "Pathway C (empty sectors[], empty geo[], 1.5°C)",
+      "no sectors, no geo, no temp",
+      "empty sectors[], empty geo[], 1.5°C",
     ]);
-    expectHidden([
-      "Pathway B (Power, Europe, 2°C)",
-      "Pathway D (Industry, Asia, no temp)",
-    ]);
+    expectHidden(["Power, Europe, 2°C", "Industry, Asia, no temp"]);
   });
 
   it("Geography: shows 'None' when any pathway has missing/empty geography, selecting it filters correctly", async () => {
@@ -193,13 +190,10 @@ describe("PathwaySearch integration: dropdowns render and filter with 'None'", (
 
     // Only pathways with no geography: A (undefined), C (empty array)
     expectVisible([
-      "Pathway A (no sectors, no geo, no temp)",
-      "Pathway C (empty sectors[], empty geo[], 1.5°C)",
+      "no sectors, no geo, no temp",
+      "empty sectors[], empty geo[], 1.5°C",
     ]);
-    expectHidden([
-      "Pathway B (Power, Europe, 2°C)",
-      "Pathway D (Industry, Asia, no temp)",
-    ]);
+    expectHidden(["Power, Europe, 2°C", "Industry, Asia, no temp"]);
   });
 
   it("Temperature: shows 'None' when any pathway omits temperature, selecting it filters correctly", async () => {
@@ -208,14 +202,8 @@ describe("PathwaySearch integration: dropdowns render and filter with 'None'", (
     await selectOption("None");
 
     // Pathways with no temperature: A and D
-    expectVisible([
-      "Pathway A (no sectors, no geo, no temp)",
-      "Pathway D (Industry, Asia, no temp)",
-    ]);
-    expectHidden([
-      "Pathway B (Power, Europe, 2°C)",
-      "Pathway C (empty sectors[], empty geo[], 1.5°C)",
-    ]);
+    expectVisible(["no sectors, no geo, no temp", "Industry, Asia, no temp"]);
+    expectHidden(["Power, Europe, 2°C", "empty sectors[], empty geo[], 1.5°C"]);
   });
 
   // Concrete selection (requested): pick a real value and ensure only matching pathways remain
@@ -224,25 +212,22 @@ describe("PathwaySearch integration: dropdowns render and filter with 'None'", (
     // Select a real sector option
     await selectOption("Power");
     // Only Pathway B has sector "Power"
-    expectVisible(["Pathway B (Power, Europe, 2°C)"]);
+    expectVisible(["Power, Europe, 2°C"]);
     expectHidden([
-      "Pathway A (no sectors, no geo, no temp)",
-      "Pathway C (empty sectors[], empty geo[], 1.5°C)",
-      "Pathway D (Industry, Asia, no temp)",
+      "no sectors, no geo, no temp",
+      "empty sectors[], empty geo[], 1.5°C",
+      "Industry, Asia, no temp",
     ]);
   });
 
   it("Sector: selecting a concrete option (metric) filters correctly", async () => {
     await openDropdown(/metric/i);
     await selectOption("Capacity");
-    expectVisible([
-      "Pathway B (Power, Europe, 2°C)",
-      "Pathway D (Industry, Asia, no temp)",
-    ]);
+    expectVisible(["Power, Europe, 2°C", "Industry, Asia, no temp"]);
     expectHidden([
-      "Pathway A (no sectors, no geo, no temp)",
-      "Pathway C (empty sectors[], empty geo[], 1.5°C)",
-      "Pathway E (Power, Europe+Asia, 2°C)",
+      "no sectors, no geo, no temp",
+      "empty sectors[], empty geo[], 1.5°C",
+      "Power, Europe+Asia, 2°C",
     ]);
   });
 
@@ -253,20 +238,20 @@ describe("PathwaySearch integration: dropdowns render and filter with 'None'", (
 
     // ANY (default): shows anything with Europe OR Asia → B, D, E
     expectVisible([
-      "Pathway B (Power, Europe, 2°C)",
-      "Pathway D (Industry, Asia, no temp)",
-      "Pathway E (Power, Europe+Asia, 2°C)",
+      "Power, Europe, 2°C",
+      "Industry, Asia, no temp",
+      "Power, Europe+Asia, 2°C",
     ]);
 
     // Switch to ALL inside the open menu
     await u.click(screen.getByTestId("mode-toggle"));
     // Only E has both Europe and Asia
-    expectVisible(["Pathway E (Power, Europe+Asia, 2°C)"]);
+    expectVisible(["Power, Europe+Asia, 2°C"]);
     expectHidden([
-      "Pathway B (Power, Europe, 2°C)",
-      "Pathway D (Industry, Asia, no temp)",
-      "Pathway A (no sectors, no geo, no temp)",
-      "Pathway C (empty sectors[], empty geo[], 1.5°C)",
+      "Power, Europe, 2°C",
+      "Industry, Asia, no temp",
+      "no sectors, no geo, no temp",
+      "empty sectors[], empty geo[], 1.5°C",
     ]);
   });
 
@@ -277,24 +262,24 @@ describe("PathwaySearch integration: dropdowns render and filter with 'None'", (
 
     // ANY
     expectVisible([
-      "Pathway B (Power, Europe, 2°C)",
-      "Pathway D (Industry, Asia, no temp)",
-      "Pathway E (Power, Europe+Asia, 2°C)",
+      "Power, Europe, 2°C",
+      "Industry, Asia, no temp",
+      "Power, Europe+Asia, 2°C",
     ]);
     expectHidden([
-      "Pathway A (no sectors, no geo, no temp)",
-      "Pathway C (empty sectors[], empty geo[], 1.5°C)",
+      "no sectors, no geo, no temp",
+      "empty sectors[], empty geo[], 1.5°C",
     ]);
 
     // Switch to ALL inside the open menu
     await u.click(screen.getByTestId("mode-toggle"));
     // ALL
-    expectVisible(["Pathway D (Industry, Asia, no temp)"]);
+    expectVisible(["Industry, Asia, no temp"]);
     expectHidden([
-      "Pathway A (no sectors, no geo, no temp)",
-      "Pathway B (Power, Europe, 2°C)",
-      "Pathway C (empty sectors[], empty geo[], 1.5°C)",
-      "Pathway E (Power, Europe+Asia, 2°C)",
+      "no sectors, no geo, no temp",
+      "Power, Europe, 2°C",
+      "empty sectors[], empty geo[], 1.5°C",
+      "Power, Europe+Asia, 2°C",
     ]);
   });
 });

--- a/src/schema/pathwayMetadata.v1.json
+++ b/src/schema/pathwayMetadata.v1.json
@@ -17,8 +17,8 @@
     },
     "name": {
       "description": "Name of the pathway.",
-      "type": "string",
-      "maxLength": 100
+      "$ref": "./common/label.v1.json",
+      "tsType": "import('./common/label.v1').LabelV1"
     },
     "description": {
       "description": "Brief description of the pathway.",

--- a/src/types/pathwayMetadata.v1.d.ts
+++ b/src/types/pathwayMetadata.v1.d.ts
@@ -5,6 +5,10 @@
  */
 
 /**
+ * Name of the pathway.
+ */
+export type Label = import("./common/label.v1").LabelV1;
+/**
  * Bibliographic information about the report or dataset.
  */
 export type Publication = import("./publication.v1").PublicationV1;
@@ -21,10 +25,7 @@ export interface PathwayMetadataV1 {
    * The unique identifier for a pathway.
    */
   id: string;
-  /**
-   * Name of the pathway.
-   */
-  name: string;
+  name: Label;
   /**
    * Brief description of the pathway.
    */

--- a/src/utils/searchUtils.ts
+++ b/src/utils/searchUtils.ts
@@ -245,7 +245,8 @@ export const filterPathways = (
     if (filters.searchTerm && filters.searchTerm.trim() !== "") {
       const searchTerm = filters.searchTerm.toLowerCase();
       const searchFields = [
-        pathway.name,
+        pathway.name.full,
+        pathway.name.short,
         pathway.description,
         pathway.pathwayType,
         pathway.modelYearNetzero,

--- a/src/utils/validateData.test.tsx
+++ b/src/utils/validateData.test.tsx
@@ -76,7 +76,7 @@ describe("pathway schema enforces expected limits", () => {
         data: {
           ...basePathway,
           id: "scn-2",
-          name: "Other",
+          name: { full: "Other" },
           geography: ["Global", "EU"],
         },
       },
@@ -122,13 +122,24 @@ describe("pathway schema enforces expected limits", () => {
   });
 
   it("enforces maxLength for short strings", () => {
-    const long = "x".repeat(101);
+    const long = "x".repeat(201);
     fail(
       {
         name: "maxlength.json",
-        data: { ...basePathway, name: long },
+        data: { ...basePathway, name: { full: long } },
       },
-      /name must NOT have more than 100 characters/,
+      /name\/full must NOT have more than 200 characters/,
+    );
+  });
+
+  it("enforces maxLength for short strings", () => {
+    const long = "x".repeat(201);
+    fail(
+      {
+        name: "maxlength.json",
+        data: { ...basePathway, name: { short: long } },
+      },
+      /name\/short must NOT have more than 20 characters/,
     );
   });
 

--- a/testdata/valid/pathwayMetadata_full.json
+++ b/testdata/valid/pathwayMetadata_full.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://pathways-library.rmi.org/schema/pathwayMetadata.v1.json",
   "id": "pathway-simple-full",
-  "name": "Full Enums Pathway",
+  "name": { "full": "Full Enums Pathway", "short": "FEP" },
   "publication": {
     "title": { "full": "Example Title", "short": "Example" },
     "subtitle": "An Example Subtitle",

--- a/testdata/valid/pathwayMetadata_full.json
+++ b/testdata/valid/pathwayMetadata_full.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://pathways-library.rmi.org/schema/pathwayMetadata.v1.json",
   "id": "pathway-simple-full",
-  "name": { "full": "Full Enums Pathway", "short": "FEP" },
+  "name": { "full": "Full Enums Pathway", "short": "FullEnum" },
   "publication": {
     "title": { "full": "Example Title", "short": "Example" },
     "subtitle": "An Example Subtitle",

--- a/testdata/valid/pathwayMetadata_minimal.json
+++ b/testdata/valid/pathwayMetadata_minimal.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://pathways-library.rmi.org/schema/pathwayMetadata.v1.json",
   "id": "pathway-minimal",
-  "name": "Minimal Pathway",
+  "name": { "full": "Minimal Pathway" },
   "publication": {
     "title": { "full": "Example Title" },
     "publisher": { "full": "Example Publisher" },

--- a/testdata/valid/pathwayMetadata_sample_01.json
+++ b/testdata/valid/pathwayMetadata_sample_01.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://pathways-library.rmi.org/schema/pathwayMetadata.v1.json",
   "id": "sample-01",
-  "name": "Sample Pathway 01",
+  "name": { "full": "Sample Pathway 01" },
   "publication": {
     "title": { "full": "Example Title" },
     "publisher": { "full": "Example Publisher" },

--- a/testdata/valid/pathwayMetadata_sample_02.json
+++ b/testdata/valid/pathwayMetadata_sample_02.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://pathways-library.rmi.org/schema/pathwayMetadata.v1.json",
   "id": "sample-02",
-  "name": "Sample Pathway 02",
+  "name": { "full": "Sample Pathway 02" },
   "publication": {
     "title": { "full": "Example Title" },
     "publisher": { "full": "Example Publisher" },

--- a/testdata/valid/pathwayMetadata_sample_03.json
+++ b/testdata/valid/pathwayMetadata_sample_03.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://pathways-library.rmi.org/schema/pathwayMetadata.v1.json",
   "id": "sample-03",
-  "name": "Sample Pathway 03",
+  "name": { "full": "Sample Pathway 03" },
   "publication": {
     "title": { "full": "Example Title" },
     "publisher": { "full": "Example Publisher" },

--- a/testdata/valid/pathwayMetadata_sample_04.json
+++ b/testdata/valid/pathwayMetadata_sample_04.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://pathways-library.rmi.org/schema/pathwayMetadata.v1.json",
   "id": "sample-04",
-  "name": "Sample Pathway 04",
+  "name": { "full": "Sample Pathway 04" },
   "publication": {
     "title": { "full": "Example Title" },
     "publisher": { "full": "Example Publisher" },

--- a/testdata/valid/pathwayMetadata_standard.json
+++ b/testdata/valid/pathwayMetadata_standard.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://pathways-library.rmi.org/schema/pathwayMetadata.v1.json",
   "id": "pathway-simple-standard",
-  "name": "Simple Standard Pathway",
+  "name": { "full": "Simple Standard Pathway", "short": "SimpStanPath" },
   "publication": {
     "title": { "full": "Example Title" },
     "publisher": { "full": "Example Publisher" },


### PR DESCRIPTION
Use existing `label` subschema for pathway `name`, giving access toa `full`/`short` name distinction that we can use in cards/page titles, etc.

* introduce full/short name distinction
* Update test and data files
* update calls to `pathway.name` to use new object