### PR TITLE
feat(search): refine net-zero year dropdown label

### DIFF
--- a/src/components/SearchSection.test.tsx
+++ b/src/components/SearchSection.test.tsx
@@ -62,7 +62,7 @@ describe("SearchSection", () => {
       screen.getByRole("button", { name: /^Pathway Type\b/i }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: /^Target Year\b/i }),
+      screen.getByRole("button", { name: /^Net Zero By\b/i }),
     ).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: /^Temperature\b/i }),
@@ -171,7 +171,7 @@ describe("SearchSection", () => {
   describe("does NOT render ANY/ALL toggle for scalar facets", () => {
     for (const facet of [
       "Pathway Type",
-      "Target Year",
+      "Net Zero By",
       "Temperature",
     ] as const) {
       it(`facet: ${facet}`, () => {

--- a/src/components/SearchSection.tsx
+++ b/src/components/SearchSection.tsx
@@ -126,7 +126,7 @@ const SearchSection: React.FC<SearchSectionProps> = ({
         />
 
         <MultiSelectDropdown<number>
-          label="Target Year"
+          label="Net Zero By"
           options={modelYearNetzeroOptions}
           value={filters.modelYearNetzero}
           onChange={(arr) => onFilterChange("modelYearNetzero", arr)}


### PR DESCRIPTION
Previously the label said "Target Year" which doesn't make a whole lot of sense. 
Now it says "Net Zero By..." which is more evocative of what the value actually represents.