### PR TITLE
Refactor/additional info box (PBTAR-117)

### DIFF
--- a/src/components/AdditionalInfoBox.tsx
+++ b/src/components/AdditionalInfoBox.tsx
@@ -1,0 +1,41 @@
+// src/components/AdditionalInfoBox.tsx
+import React from "react";
+import clsx from "clsx";
+
+type Props = {
+  title?: string;
+  children: React.ReactNode;
+  actions?: React.ReactNode;
+  className?: string;
+};
+
+/** Shared visual container for PublicationBlock and DownloadDataset */
+export default function AdditionalInfoBox({
+  title,
+  children,
+  actions,
+  className,
+}: Props) {
+  return (
+    <section className="mt-8">
+      {title && (
+        <h3 className="text-sm font-semibold text-neutral-600 mb-3">{title}</h3>
+      )}
+      <div
+        className={clsx(
+          "w-full bg-white border border-neutral-200 rounded-lg p-4 shadow-sm",
+          className,
+        )}
+      >
+        <div className="flex justify-between gap-4">
+          <div className="min-w-0 flex-1">{children}</div>
+          {actions && (
+            <div className="flex flex-col items-end gap-2 shrink-0">
+              {actions}
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/DownloadDataset.tsx
+++ b/src/components/DownloadDataset.tsx
@@ -1,5 +1,6 @@
 // src/components/DownloadDataset.tsx
 import React from "react";
+import AdditionalInfoBox from "./AdditionalInfoBox";
 
 type Props = {
   label: string;
@@ -15,28 +16,24 @@ export default function DownloadDataset({
   className,
 }: Props) {
   return (
-    <div
-      className={[
-        "flex items-center justify-between gap-4 rounded-2xl border border-neutral-200 p-4 shadow-sm",
-        "bg-white",
-        className ?? "",
-      ].join(" ")}
+    <AdditionalInfoBox
+      title="Related Dataset"
+      className={className}
+      actions={
+        <a
+          href={href}
+          download
+          rel="noopener noreferrer"
+          className="inline-flex items-center px-4 py-2 bg-energy text-white rounded-md hover:bg-energy-700 transition-colors duration-200"
+        >
+          Download
+        </a>
+      }
     >
-      <div className="min-w-0">
-        <p className="text-rmigray-700">{label}</p>
-        {summary ? (
-          <p className="text-xs text-neutral-500 mt-1 truncate">{summary}</p>
-        ) : null}
-      </div>
-
-      <a
-        href={href}
-        download
-        rel="noopener noreferrer"
-        className="inline-flex items-center px-4 py-2 bg-energy text-white rounded-md hover:bg-energy-700 transition-colors duration-200"
-      >
-        Download
-      </a>
-    </div>
+      <p className="text-rmigray-700">{label}</p>
+      {summary && (
+        <p className="text-xs text-neutral-500 mt-1 truncate">{summary}</p>
+      )}
+    </AdditionalInfoBox>
   );
 }

--- a/src/components/PublicationBlock.tsx
+++ b/src/components/PublicationBlock.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { ExternalLink } from "lucide-react";
 import { PublicationType } from "../types";
+import AdditionalInfoBox from "./AdditionalInfoBox";
 
 type labelObj = PublicationType["publisher"];
 
@@ -68,46 +69,11 @@ export default function PublicationBlock({
   const authors = formatAuthors(publication.author);
 
   return (
-    <section>
-      <h2 className="text-xl font-semibold text-rmigray-800 mb-3">
-        Data Source
-      </h2>
-
-      <div className="bg-neutral-50 border border-neutral-200 rounded-lg p-4">
-        <div className="text-rmigray-700 mb-3 leading-relaxed">
-          <p>{formatCitation(publication)}</p>
-
-          {(publication.doi ||
-            publication.isbn ||
-            publication.issn ||
-            authors) && (
-            <div className="mt-2 flex flex-wrap gap-2 text-sm text-rmigray-700">
-              {authors && (
-                <span className="inline-block rounded bg-neutral-100 px-2 py-1 border border-neutral-200">
-                  {authors}
-                </span>
-              )}
-              {publication.doi && (
-                <span className="inline-block rounded bg-neutral-100 px-2 py-1 border border-neutral-200">
-                  DOI: {publication.doi}
-                </span>
-              )}
-              {publication.isbn && (
-                <span className="inline-block rounded bg-neutral-100 px-2 py-1 border border-neutral-200">
-                  ISBN: {publication.isbn}
-                </span>
-              )}
-              {publication.issn && (
-                <span className="inline-block rounded bg-neutral-100 px-2 py-1 border border-neutral-200">
-                  ISSN: {publication.issn}
-                </span>
-              )}
-            </div>
-          )}
-        </div>
-
-        {links.length > 0 && (
-          <div className="flex flex-col sm:flex-row gap-3">
+    <AdditionalInfoBox
+      title="Data Source"
+      actions={
+        links.length > 0 ? (
+          <div className="flex flex-col gap-2">
             {links.map((l, i) => (
               <a
                 key={`${l.url}-${i}`}
@@ -124,8 +90,40 @@ export default function PublicationBlock({
               </a>
             ))}
           </div>
+        ) : undefined
+      }
+    >
+      <div className="text-rmigray-700 mb-3 leading-relaxed">
+        <p>{formatCitation(publication)}</p>
+
+        {(publication.doi ||
+          publication.isbn ||
+          publication.issn ||
+          authors) && (
+          <div className="mt-2 flex flex-wrap gap-2 text-sm text-rmigray-700">
+            {authors && (
+              <span className="inline-block rounded bg-neutral-100 px-2 py-1 border border-neutral-200">
+                {authors}
+              </span>
+            )}
+            {publication.doi && (
+              <span className="inline-block rounded bg-neutral-100 px-2 py-1 border border-neutral-200">
+                DOI: {publication.doi}
+              </span>
+            )}
+            {publication.isbn && (
+              <span className="inline-block rounded bg-neutral-100 px-2 py-1 border border-neutral-200">
+                ISBN: {publication.isbn}
+              </span>
+            )}
+            {publication.issn && (
+              <span className="inline-block rounded bg-neutral-100 px-2 py-1 border border-neutral-200">
+                ISSN: {publication.issn}
+              </span>
+            )}
+          </div>
         )}
       </div>
-    </section>
+    </AdditionalInfoBox>
   );
 }

--- a/src/pages/PathwayDetailPage.tsx
+++ b/src/pages/PathwayDetailPage.tsx
@@ -202,27 +202,20 @@ const PathwayDetailPage: React.FC = () => {
 
               <PublicationBlock publication={pathway.publication} />
 
-              {tsIndexLoaded && datasets.length > 0 ? (
-                <section className="mt-8">
-                  <h3 className="text-sm font-semibold text-neutral-600 mb-3">
-                    Related datasets
-                  </h3>
-                  <div className="grid gap-3">
-                    {datasets.map((d) => {
-                      const label = d.label ?? d.datasetId;
-                      const summary = summarizeSummary(d.summary);
-                      return (
-                        <DownloadDataset
-                          key={d.datasetId}
-                          label={label}
-                          href={d.path}
-                          summary={summary}
-                        />
-                      );
-                    })}
-                  </div>
-                </section>
-              ) : null}
+              {tsIndexLoaded && datasets.length > 0
+                ? datasets.map((d) => {
+                    const label = d.label ?? d.datasetId;
+                    const summary = summarizeSummary(d.summary);
+                    return (
+                      <DownloadDataset
+                        key={d.datasetId}
+                        label={label}
+                        href={d.path}
+                        summary={summary}
+                      />
+                    );
+                  })
+                : null}
             </div>
 
             <div className="md:col-span-5">


### PR DESCRIPTION
Standardize box UI on Pathway detail page.

Introduces `AdditionalInfoBox`:
Intended for use on `PathwayDetailPage`, takes an optional string title and
`actions` ReactNode arguments intended for displaying buttons for links.

`actions` nodes display in stacked column on the right, with content filling on the left.

https://proud-glacier-0f640931e-575.westus2.2.azurestaticapps.net/pathway/IEA-APS-2024

<img width="1460" height="668" alt="Screenshot_2025-11-12_16 53 38@2x" src="https://github.com/user-attachments/assets/5c62678d-65c1-4561-9185-49d1209f7c6a" />

