### PR TITLE
feat(details): remove 'Sectors:' label from Sectors section (PBTAR-132)

### DIFF
--- a/src/pages/PathwayDetailPage.tsx
+++ b/src/pages/PathwayDetailPage.tsx
@@ -317,9 +317,6 @@ const PathwayDetailPage: React.FC = () => {
                 </h3>
                 {/* Sectors section with dynamic badge count */}
                 <div className="mb-3">
-                  <p className="text-xs font-medium text-rmigray-500 mb-1">
-                    Sectors:
-                  </p>
                   <BadgeArray
                     variant="sector"
                     tooltipGetter={getSectorTooltip}


### PR DESCRIPTION
Removed the second "Sectors:" label from PathwayDetails view (no other section has this duplicated label).

Closes PBTAR-132

<img width="531" height="440" alt="Screenshot 2025-11-12 at 17 05 25" src="https://github.com/user-attachments/assets/da06892d-f15d-436b-902a-52ddcb486011" />
