### PR TITLE
update jrc geco 1.5c description

### DIFF
--- a/src/data/index.gen.ts
+++ b/src/data/index.gen.ts
@@ -112,6 +112,20 @@ export const index: TimeseriesIndex = {
         path: "/data/iea/IEA-STEPS-2024_TS.csv",
       },
     ],
+    "JETP-CIPP-2023": [
+      {
+        datasetId: "JETP-CIPP-2023_TS",
+        label:
+          "Comprehensive Investment and Policy Plan (CIPP) Timeseries Data",
+        summary: {
+          rowCount: 126,
+          yearRange: [2022, 2050],
+          sectorCount: 1,
+          geographyCount: 1,
+        },
+        path: "/data/jetp-id/jetp-cipp-2023_timeseries.csv",
+      },
+    ],
     "JRC-GECO-1.5C-2025": [
       {
         datasetId: "JRC-GECO-1.5C-2025_TS",
@@ -155,7 +169,7 @@ export const index: TimeseriesIndex = {
     "TZ-BAU-2024": [
       {
         datasetId: "TZ-BAU-2024_TS",
-        label: "Business as Usual (BAU)",
+        label: "Business as Usual (BAU) Timeseries Data",
         summary: {
           rowCount: 418,
           yearRange: [2023, 2035],
@@ -168,7 +182,7 @@ export const index: TimeseriesIndex = {
     "TZ-EBAU-2024": [
       {
         datasetId: "TZ-EBAU-2024_TS",
-        label: "Enhanced Business as Usual (EBAU)",
+        label: "Enhanced Business as Usual (EBAU) Timeseries Data",
         summary: {
           rowCount: 418,
           yearRange: [2023, 2035],
@@ -181,7 +195,7 @@ export const index: TimeseriesIndex = {
     "TZ-ISG-2024": [
       {
         datasetId: "TZ-ISG-2024_TS",
-        label: "Indonesia Supergrid (ISG)",
+        label: "Indonesia Supergrid (ISG) Timeseries Data",
         summary: {
           rowCount: 418,
           yearRange: [2023, 2035],
@@ -194,7 +208,7 @@ export const index: TimeseriesIndex = {
     "TZ-REGI-2024": [
       {
         datasetId: "TZ-REGI-2024_TS",
-        label: "Regional Interconnection (REGI)",
+        label: "Regional Interconnection (REGI) Timeseries Data",
         summary: {
           rowCount: 418,
           yearRange: [2023, 2035],
@@ -290,6 +304,18 @@ export const index: TimeseriesIndex = {
       },
       path: "/data/iea/IEA-STEPS-2024_TS.csv",
     },
+    "JETP-CIPP-2023_TS": {
+      datasetId: "JETP-CIPP-2023_TS",
+      pathwayIds: ["JETP-CIPP-2023"],
+      label: "Comprehensive Investment and Policy Plan (CIPP) Timeseries Data",
+      summary: {
+        rowCount: 126,
+        yearRange: [2022, 2050],
+        sectorCount: 1,
+        geographyCount: 1,
+      },
+      path: "/data/jetp-id/jetp-cipp-2023_timeseries.csv",
+    },
     "JRC-GECO-1.5C-2025_TS": {
       datasetId: "JRC-GECO-1.5C-2025_TS",
       pathwayIds: ["JRC-GECO-1.5C-2025"],
@@ -330,7 +356,7 @@ export const index: TimeseriesIndex = {
     "TZ-BAU-2024_TS": {
       datasetId: "TZ-BAU-2024_TS",
       pathwayIds: ["TZ-BAU-2024"],
-      label: "Business as Usual (BAU)",
+      label: "Business as Usual (BAU) Timeseries Data",
       summary: {
         rowCount: 418,
         yearRange: [2023, 2035],
@@ -342,7 +368,7 @@ export const index: TimeseriesIndex = {
     "TZ-EBAU-2024_TS": {
       datasetId: "TZ-EBAU-2024_TS",
       pathwayIds: ["TZ-EBAU-2024"],
-      label: "Enhanced Business as Usual (EBAU)",
+      label: "Enhanced Business as Usual (EBAU) Timeseries Data",
       summary: {
         rowCount: 418,
         yearRange: [2023, 2035],
@@ -354,7 +380,7 @@ export const index: TimeseriesIndex = {
     "TZ-ISG-2024_TS": {
       datasetId: "TZ-ISG-2024_TS",
       pathwayIds: ["TZ-ISG-2024"],
-      label: "Indonesia Supergrid (ISG)",
+      label: "Indonesia Supergrid (ISG) Timeseries Data",
       summary: {
         rowCount: 418,
         yearRange: [2023, 2035],
@@ -366,7 +392,7 @@ export const index: TimeseriesIndex = {
     "TZ-REGI-2024_TS": {
       datasetId: "TZ-REGI-2024_TS",
       pathwayIds: ["TZ-REGI-2024"],
-      label: "Regional Interconnection (REGI)",
+      label: "Regional Interconnection (REGI) Timeseries Data",
       summary: {
         rowCount: 418,
         yearRange: [2023, 2035],

--- a/src/data/jrc/jrc-geco_1_5-2025.json
+++ b/src/data/jrc/jrc-geco_1_5-2025.json
@@ -23,7 +23,7 @@
     ]
   },
   "name": { "full": "1.5°C scenario", "short": "1.5°C" },
-  "description": "Global normative pathway limiting warming to 1.5°C, with net zero achieved in 2060.",
+  "description": "Global normative pathway peaking at 1.5°C warming before declining to 1.3°C by 2100.",
   "geography": [
     "Global",
     "GB",

--- a/src/data/jrc/jrc-geco_1_5-2025_timeseries.json
+++ b/src/data/jrc/jrc-geco_1_5-2025_timeseries.json
@@ -3,7 +3,7 @@
   "pathwayId": ["JRC-GECO-1.5C-2025"],
   "id": "JRC-GECO-1.5C-2025_TS",
   "name": "1.5C scenario (1.5C) Timeseries Data",
-  "description": "Global normative pathway limiting warming to 1.5C, with net zero achieved in 2060.",
+  "description": "Global normative pathway peaking at 1.5°C warming before declining to 1.3°C by 2100.",
   "publisher": "JRC",
   "publicationName": "Global Energy and Climate Outlook (GECO)",
   "publicationYear": 2024,


### PR DESCRIPTION
closes https://rmi1.atlassian.net/browse/PBTAR-135

- updates description of pathway `"JRC-GECO-1.5C-2025"` to `"Global normative pathway peaking at 1.5°C warming before declining to 1.3°C by 2100."` to clarify the meaning of 1.5C and 1.3C both displayed on the pathway card