### PR TITLE
build(test): Update test config to use `pool: threads`

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "jsdom",
+    pool: "threads",
     setupFiles: ["./src/test/setup.ts", "./src/test/failOnReactWarnings.ts"],
     restoreMocks: true,
   },


### PR DESCRIPTION
Previously, running `test:watch` hung (tests never completed). Setting this change in my config has restored functionality