### PR TITLE
`MultiLineChart`: simple dodge labels (PBTAR-133)

### DIFF
--- a/src/components/MultiLineChart.tsx
+++ b/src/components/MultiLineChart.tsx
@@ -96,7 +96,7 @@ export default function MultiLineChart({
       positions: number[],
       separation: number = 12,
       maxiter: number = 10,
-      maxerror: number = 1e-1
+      maxerror: number = 1e-1,
     ): number[] {
       positions = Array.from(positions);
       const n = positions.length;

--- a/src/components/MultiLineChart.tsx
+++ b/src/components/MultiLineChart.tsx
@@ -35,6 +35,8 @@ interface MultiLineChartProps {
 
 type GroupedData = [string, DataPoint[]];
 
+type LabelData = { label: string; x: number; y: number };
+
 export default function MultiLineChart({
   data,
   width = 600,
@@ -208,7 +210,7 @@ export default function MultiLineChart({
 
     (
       select(lines.current)
-        .selectAll<SVGTextElement, GroupedData>(".label")
+        .selectAll<SVGTextElement, LabelData>(".label")
         .data(labelData)
         .join("text") as UpdateSelection
     )

--- a/src/components/MultiLineChart.tsx
+++ b/src/components/MultiLineChart.tsx
@@ -214,10 +214,10 @@ export default function MultiLineChart({
         .data(labelData)
         .join("text") as UpdateSelection
     )
-      .text((d) => d.label)
+      .text((d) => d.label as string)
       .attr("class", "label")
-      .attr("x", (d) => d.x)
-      .attr("y", (d) => d.y)
+      .attr("x", (d) => d.x as number)
+      .attr("y", (d) => d.y as number)
       .attr("dx", "18")
       .attr("dy", "5")
       .attr("font-size", "12px");

--- a/src/components/MultiLineChart.tsx
+++ b/src/components/MultiLineChart.tsx
@@ -92,7 +92,12 @@ export default function MultiLineChart({
       .x((d) => x(parse(d.year) as Date))
       .y((d) => y(d.value));
 
-    function dodge(positions, separation = 12, maxiter = 10, maxerror = 1e-1) {
+    function dodge(
+      positions: number[],
+      separation: number = 12,
+      maxiter: number = 10,
+      maxerror: number = 1e-1
+    ): number[] {
       positions = Array.from(positions);
       const n = positions.length;
       if (!positions.every(isFinite)) throw new Error("invalid position");


### PR DESCRIPTION
A "simplistic" algorithm to dodge labels in the `MultiLineChart`.

not perfect/ideal, but probably an improvement

before:
<img width="465" height="344" alt="Screenshot 2025-11-17 at 10 54 45" src="https://github.com/user-attachments/assets/23bcfd6b-e554-4bcb-b0bd-f4c671624966" />

after:
<img width="474" height="359" alt="Screenshot 2025-11-17 at 10 54 33" src="https://github.com/user-attachments/assets/d66952f0-ccee-4c7f-98dd-1b1abd403490" />
