### PR TITLE
fix(card): truncate pathway type text on header

### DIFF
--- a/src/components/PathwayCard.tsx
+++ b/src/components/PathwayCard.tsx
@@ -80,8 +80,8 @@ const PathwayCard: React.FC<PathwayCardProps> = ({
   return (
     <div className="bg-white rounded-lg shadow-md overflow-hidden hover:shadow-lg transition-shadow duration-300 flex flex-col h-full border border-neutral-200">
       <div className="flex items-stretch">
-        <div className="px-5 py-3 bg-neutral-100 flex-grow flex items-center">
-          <span className="text-sm font-medium text-rmigray-700 uppercase">
+        <div className="px-5 py-3 bg-neutral-100 flex-grow flex items-center min-w-0">
+          <span className="text-sm font-medium text-rmigray-700 uppercase truncate overflow-hidden whitespace-nowrap w-full">
             {highlightTextIfSearchMatch(pathway.pathwayType)} Pathway
           </span>
         </div>
@@ -98,12 +98,12 @@ const PathwayCard: React.FC<PathwayCardProps> = ({
             </div>
           ) : null}
           {pathway.modelYearNetzero ? (
-            <div className="px-5 py-3 flex items-center bg-rmiblue-100">
+            <div className="px-5 py-3 flex items-center bg-rmiblue-100 min-w-[80px]">
               <div className="flex flex-col items-center">
-                <span className="text-[10px] text-rmigray-600 leading-tight h-[14px]">
+                <span className="text-[10px] text-rmigray-600 leading-tight h-[14px] whitespace-nowrap">
                   Net Zero By
                 </span>
-                <span className="text-sm font-medium text-rmigray-700">
+                <span className="text-sm font-medium text-rmigray-700 truncate overflow-hidden whitespace-nowrap max-w-[60px]">
                   {highlightTextIfSearchMatch(pathway.modelYearNetzero)}
                 </span>
               </div>
@@ -194,7 +194,7 @@ const PathwayCard: React.FC<PathwayCardProps> = ({
                 <HighlightedText
                   text={truncateText(
                     pathway.publication.title.short ||
-                      pathway.publication.title.full,
+                    pathway.publication.title.full,
                     40, // <-- set your desired max length here
                   )}
                   searchTerm={searchTerm}

--- a/src/components/PathwayCard.tsx
+++ b/src/components/PathwayCard.tsx
@@ -194,7 +194,7 @@ const PathwayCard: React.FC<PathwayCardProps> = ({
                 <HighlightedText
                   text={truncateText(
                     pathway.publication.title.short ||
-                    pathway.publication.title.full,
+                      pathway.publication.title.full,
                     40, // <-- set your desired max length here
                   )}
                   searchTerm={searchTerm}


### PR DESCRIPTION
- Ensure pathway type header truncates with ellipsis on narrow screens
- Prevent "Net Zero" box from truncating or garbling text

Closes #582 
