### PR TITLE
feat(pathwaySearch): searchBox and filters span main horizontal container

### DIFF
--- a/src/components/DropdownFacetShell.tsx
+++ b/src/components/DropdownFacetShell.tsx
@@ -145,10 +145,10 @@ export default function DropdownFacetShell({
               menuWidthClassName
                 ? undefined
                 : {
-                  minWidth: menuMinWidthPx
-                    ? `${menuMinWidthPx}px`
-                    : undefined,
-                }
+                    minWidth: menuMinWidthPx
+                      ? `${menuMinWidthPx}px`
+                      : undefined,
+                  }
             }
           >
             {/* Header row: left/right zones */}
@@ -160,10 +160,10 @@ export default function DropdownFacetShell({
             <div className="p-2">
               {typeof children === "function"
                 ? (children as (api: { close: () => void }) => React.ReactNode)(
-                  {
-                    close: () => setOpen(false),
-                  },
-                )
+                    {
+                      close: () => setOpen(false),
+                    },
+                  )
                 : children}
             </div>
           </div>

--- a/src/components/DropdownFacetShell.tsx
+++ b/src/components/DropdownFacetShell.tsx
@@ -76,7 +76,7 @@ export default function DropdownFacetShell({
         ref={triggerRef}
         type="button"
         className={clsx(
-          "inline-flex w-auto items-center justify-between rounded-md px-3 py-2 text-left text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500",
+          "inline-flex w-full items-center justify-between rounded-md px-3 py-2 text-left text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500",
           active
             ? "text-energy-800 bg-energy-100 border border-energy-100"
             : "text-rmigray-800 bg-white border border-gray-300 hover:bg-gray-50",
@@ -145,10 +145,10 @@ export default function DropdownFacetShell({
               menuWidthClassName
                 ? undefined
                 : {
-                    minWidth: menuMinWidthPx
-                      ? `${menuMinWidthPx}px`
-                      : undefined,
-                  }
+                  minWidth: menuMinWidthPx
+                    ? `${menuMinWidthPx}px`
+                    : undefined,
+                }
             }
           >
             {/* Header row: left/right zones */}
@@ -160,10 +160,10 @@ export default function DropdownFacetShell({
             <div className="p-2">
               {typeof children === "function"
                 ? (children as (api: { close: () => void }) => React.ReactNode)(
-                    {
-                      close: () => setOpen(false),
-                    },
-                  )
+                  {
+                    close: () => setOpen(false),
+                  },
+                )
                 : children}
             </div>
           </div>

--- a/src/components/SearchBox.tsx
+++ b/src/components/SearchBox.tsx
@@ -24,10 +24,11 @@ const SearchBox: React.FC<SearchBoxProps> = ({
 
   return (
     <div
-      className={`flex items-center w-full rounded-md border transition-all duration-200 bg-white ${isFocused
-        ? "border-energy-400 ring-2 ring-energy-100"
-        : "border-neutral-300"
-        }`}
+      className={`flex items-center w-full rounded-md border transition-all duration-200 bg-white ${
+        isFocused
+          ? "border-energy-400 ring-2 ring-energy-100"
+          : "border-neutral-300"
+      }`}
     >
       <div className="pl-3 text-gray-400">
         <Search size={20} />

--- a/src/components/SearchBox.tsx
+++ b/src/components/SearchBox.tsx
@@ -24,11 +24,10 @@ const SearchBox: React.FC<SearchBoxProps> = ({
 
   return (
     <div
-      className={`flex items-center w-full max-w-169 rounded-md border transition-all duration-200 bg-white ${
-        isFocused
-          ? "border-energy-400 ring-2 ring-energy-100"
-          : "border-neutral-300"
-      }`}
+      className={`flex items-center w-full rounded-md border transition-all duration-200 bg-white ${isFocused
+        ? "border-energy-400 ring-2 ring-energy-100"
+        : "border-neutral-300"
+        }`}
     >
       <div className="pl-3 text-gray-400">
         <Search size={20} />

--- a/src/components/SearchSection.tsx
+++ b/src/components/SearchSection.tsx
@@ -93,74 +93,87 @@ const SearchSection: React.FC<SearchSectionProps> = ({
           onClear={onClear}
         />
       </div>
+      <div
+        className="grid gap-2 grid-cols-[repeat(auto-fit,minmax(12rem,1fr))]"
+      >
+        <div>
+          <MultiSelectDropdown<string>
+            label="Geography"
+            options={geographyOptions}
+            value={filters.geography}
+            onChange={(arr) => onFilterChange("geography", arr)}
+            showModeToggle
+            mode={filters.modes?.geography ?? "ANY"}
+            onModeChange={(m) => setMode("geography", m)}
+            menuWidthClassName="w-60"
+          />
+        </div>
 
-      <div className="flex flex-wrap gap-2">
-        <MultiSelectDropdown<string>
-          label="Geography"
-          options={geographyOptions}
-          value={filters.geography}
-          onChange={(arr) => onFilterChange("geography", arr)}
-          showModeToggle
-          mode={filters.modes?.geography ?? "ANY"}
-          onModeChange={(m) => setMode("geography", m)}
-          menuWidthClassName="w-60"
-        />
+        <div>
+          <MultiSelectDropdown<string>
+            label="Pathway Type"
+            options={pathwayTypeOptions}
+            value={filters.pathwayType}
+            onChange={(arr) => onFilterChange("pathwayType", arr)}
+            showModeToggle={false}
+            mode={filters.modes?.pathwayType ?? "ANY"}
+            onModeChange={(m) => setMode("pathwayType", m)}
+          />
+        </div>
 
-        <MultiSelectDropdown<string>
-          label="Pathway Type"
-          options={pathwayTypeOptions}
-          value={filters.pathwayType}
-          onChange={(arr) => onFilterChange("pathwayType", arr)}
-          showModeToggle={false}
-          mode={filters.modes?.pathwayType ?? "ANY"}
-          onModeChange={(m) => setMode("pathwayType", m)}
-        />
+        <div>
+          <NumericRangeDropdown
+            label="Temperature (°C)"
+            minBound={tempBounds.min}
+            maxBound={tempBounds.max}
+            step={getStep("temp")}
+            value={
+              !Array.isArray(filters.modelTempIncrease)
+                ? filters.modelTempIncrease
+                : null
+            }
+            onChange={(r) => onFilterChange("modelTempIncrease", r)}
+          />
+        </div>
 
-        <NumericRangeDropdown
-          label="Temperature (°C)"
-          minBound={tempBounds.min}
-          maxBound={tempBounds.max}
-          step={getStep("temp")}
-          value={
-            !Array.isArray(filters.modelTempIncrease)
-              ? filters.modelTempIncrease
-              : null
-          }
-          onChange={(r) => onFilterChange("modelTempIncrease", r)}
-        />
+        <div>
+          <MultiSelectDropdown<string>
+            label="Policy Ambition"
+            options={policyAmbitionOptions}
+            value={filters.policyAmbition}
+            onChange={(arr) => onFilterChange("policyAmbition", arr)}
+            showModeToggle={false}
+            mode={filters.modes?.policyAmbition ?? "ANY"}
+            onModeChange={(m) => setMode("policyAmbition", m)}
+            menuWidthClassName="w-60"
+          />
+        </div>
 
-        <MultiSelectDropdown<string>
-          label="Policy Ambition"
-          options={policyAmbitionOptions}
-          value={filters.policyAmbition}
-          onChange={(arr) => onFilterChange("policyAmbition", arr)}
-          showModeToggle={false}
-          mode={filters.modes?.policyAmbition ?? "ANY"}
-          onModeChange={(m) => setMode("policyAmbition", m)}
-          menuWidthClassName="w-60"
-        />
+        <div>
+          <MultiSelectDropdown<string>
+            label="Sector"
+            options={sectorOptions}
+            value={filters.sector}
+            onChange={(arr) => onFilterChange("sector", arr)}
+            showModeToggle
+            mode={filters.modes?.sector ?? "ANY"}
+            onModeChange={(m) => setMode("sector", m)}
+            menuWidthClassName="w-60"
+          />
+        </div>
 
-        <MultiSelectDropdown<string>
-          label="Sector"
-          options={sectorOptions}
-          value={filters.sector}
-          onChange={(arr) => onFilterChange("sector", arr)}
-          showModeToggle
-          mode={filters.modes?.sector ?? "ANY"}
-          onModeChange={(m) => setMode("sector", m)}
-          menuWidthClassName="w-60"
-        />
-
-        <MultiSelectDropdown<string>
-          label="Data Availability"
-          options={dataAvailabilityOptions}
-          value={filters.dataAvailability}
-          onChange={(arr) => onFilterChange("dataAvailability", arr)}
-          showModeToggle={false}
-          mode={filters.modes?.dataAvailability ?? "ANY"}
-          onModeChange={(m) => setMode("dataAvailability", m)}
-          menuWidthClassName="w-60"
-        />
+        <div>
+          <MultiSelectDropdown<string>
+            label="Data Availability"
+            options={dataAvailabilityOptions}
+            value={filters.dataAvailability}
+            onChange={(arr) => onFilterChange("dataAvailability", arr)}
+            showModeToggle={false}
+            mode={filters.modes?.dataAvailability ?? "ANY"}
+            onModeChange={(m) => setMode("dataAvailability", m)}
+            menuWidthClassName="w-60"
+          />
+        </div>
       </div>
       <div className="mt-4 ml-1 flex items-center justify-between gap-3">
         <p className="text-sm text-rmigray-500">

--- a/src/components/SearchSection.tsx
+++ b/src/components/SearchSection.tsx
@@ -93,9 +93,7 @@ const SearchSection: React.FC<SearchSectionProps> = ({
           onClear={onClear}
         />
       </div>
-      <div
-        className="grid gap-2 grid-cols-[repeat(auto-fit,minmax(12rem,1fr))]"
-      >
+      <div className="grid gap-2 grid-cols-[repeat(auto-fit,minmax(12rem,1fr))]">
         <div>
           <MultiSelectDropdown<string>
             label="Geography"


### PR DESCRIPTION
The main UI changes here just ensure that the `searchBox` and `dropdownFilters` span the same horizontal space as the `pathwayCards` below. 

My thinking here is as follows:
- Having the SBS occupy a narrow horizontal span helps visually distinguish it as a separate "module". It also draws the attention first and gives it a bit of breathing room which is then followed by the much more densely compact "dashboard" section (think of it like reading a title and abstract in a report, before diving into the report)
- Divider should stay the full width of the main "dashboard" container

With these changes, everything under the divider line will feel like a cohesive "dashboard", and the SBS above will feel like it's own separate component

<img width="1438" height="871" alt="Screenshot 2025-11-21 at 13 32 56" src="https://github.com/user-attachments/assets/e490a146-a81d-4c04-bb5f-d99fbeb33dbc" />
