### PR TITLE
ci(timeseries): Add check that timeseries index is up to date

### DIFF
--- a/.github/rulesets/gitflow-main.json
+++ b/.github/rulesets/gitflow-main.json
@@ -71,6 +71,10 @@
           {
             "context": "Unit Tests / Run unit tests",
             "integration_id": 15368
+          },
+          {
+            "context": "Node Package Checks / Check generated timeseries index / Check generated timeseries index",
+            "integration_id": 15368
           }
         ]
       }

--- a/.github/rulesets/gitflow-main.json
+++ b/.github/rulesets/gitflow-main.json
@@ -73,7 +73,7 @@
             "integration_id": 15368
           },
           {
-            "context": "Node Package Checks / Check generated timeseries index / Check generated timeseries index",
+            "context": "Check generated timeseries index / Check generated timeseries index",
             "integration_id": 15368
           }
         ]

--- a/.github/rulesets/gitflow-production.json
+++ b/.github/rulesets/gitflow-production.json
@@ -71,6 +71,10 @@
           {
             "context": "Unit Tests / Run unit tests",
             "integration_id": 15368
+          },
+          {
+            "context": "Node Package Checks / Check generated timeseries index / Check generated timeseries index",
+            "integration_id": 15368
           }
         ]
       }

--- a/.github/rulesets/gitflow-production.json
+++ b/.github/rulesets/gitflow-production.json
@@ -73,7 +73,7 @@
             "integration_id": 15368
           },
           {
-            "context": "Node Package Checks / Check generated timeseries index / Check generated timeseries index",
+            "context": "Check generated timeseries index / Check generated timeseries index",
             "integration_id": 15368
           }
         ]

--- a/.github/workflows/node-build-committed-files.yml
+++ b/.github/workflows/node-build-committed-files.yml
@@ -1,0 +1,39 @@
+on:
+  workflow_call:
+
+jobs:
+  timeseries-index-gen:
+    name: "Check generated timeseries index"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: package.json
+          cache: "npm"
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run JSON Types render
+        run: npm run build:timeseries
+
+      - name: Compare Results
+        run: |
+          git add --all
+          changes=$(git diff-index HEAD --name-only -- $OUTPUTS)
+          if [ -n "$changes" ]; then
+            echo "Changes found after generating."
+            echo "$changes"
+            echo "Please update."
+            git --no-pager diff HEAD
+            exit 1
+          else
+            echo "No changes found after generating."
+            exit 0
+          fi

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -47,3 +47,7 @@ jobs:
   scan:
     name: "Check for forbidden patterns"
     uses: ./.github/workflows/admin-forbidden-patterns.yml
+
+  timeseries:
+    name: "Check generated timeseries index"
+    uses: ./.github/workflows/node-build-committed-files.yml


### PR DESCRIPTION
Uses standard `npm run  build:timeseries` and `git diff` to ensure that generated file (which must be in repo for linting and tests) is up to date with actual timeseries data

Also updates rulesets to make this a required check

closes #588