### PR TITLE
refactor(numeric range slider): unify interface with dropdown

### DIFF
--- a/src/components/NumericRangeSlider.tsx
+++ b/src/components/NumericRangeSlider.tsx
@@ -214,8 +214,16 @@ const NumericRangeSlider: React.FC<Props> = ({
   // For visuals, show handles at bounds when undefined; hide if off the visible window.
   const effMin = isNum(min) ? min : minBound;
   const effMax = isNum(max) ? max : maxBound;
-  const minPctOnBar = toPct(clamp(effMin, minBound, maxBound), minBound, maxBound);
-  const maxPctOnBar = toPct(clamp(effMax, minBound, maxBound), minBound, maxBound);
+  const minPctOnBar = toPct(
+    clamp(effMin, minBound, maxBound),
+    minBound,
+    maxBound,
+  );
+  const maxPctOnBar = toPct(
+    clamp(effMax, minBound, maxBound),
+    minBound,
+    maxBound,
+  );
 
   // Show a handle only if that bound is explicitly set AND it lies in the visible window
   const minVisible = isNum(min) && effMin >= minBound && effMin <= maxBound;
@@ -277,7 +285,6 @@ const NumericRangeSlider: React.FC<Props> = ({
       {/* Slider track */}
       <div className="flex flex-col gap-4 md:p-5 md:gap-4 my-6">
         <div className="relative">
-
           <div
             ref={trackRef}
             onMouseDown={onTrackMouseDown}

--- a/src/components/StepByStepGuide.tsx
+++ b/src/components/StepByStepGuide.tsx
@@ -138,14 +138,7 @@ const StepByStepGuide: React.FC<StepByStepGuideProps> = ({
       componentId: "numericRange",
       componentProps: {
         stepKey: "temp",
-        minBound: optionsByFacet["modelTempIncrease"].reduce((min, current) => {
-          return current.value < min.value ? current : min;
-        }).value,
-        maxBound: optionsByFacet["modelTempIncrease"].reduce((max, current) => {
-          return current.value > max.value ? current : max;
-        }).value,
-        // recompute minBar and maxBar dynamically
-        minBar: Math.min(
+        minBound: Math.min(
           0,
           Math.floor(
             optionsByFacet["modelTempIncrease"].reduce((min, current) => {
@@ -153,7 +146,7 @@ const StepByStepGuide: React.FC<StepByStepGuideProps> = ({
             }).value,
           ),
         ),
-        maxBar: Math.ceil(
+        maxBound: Math.ceil(
           optionsByFacet["modelTempIncrease"].reduce((max, current) => {
             return current.value > max.value ? current : max;
           }).value * 1.1,
@@ -328,12 +321,6 @@ const StepByStepGuide: React.FC<StepByStepGuideProps> = ({
                       const maxBound =
                         (step.componentProps?.maxBound as number | undefined) ??
                         (nums.length ? Math.max(...nums) : 6);
-                      const minBar =
-                        (step.componentProps?.minBar as number | undefined) ??
-                        minBound;
-                      const maxBar =
-                        (step.componentProps?.maxBar as number | undefined) ??
-                        maxBound;
 
                       return (
                         <Comp
@@ -344,8 +331,6 @@ const StepByStepGuide: React.FC<StepByStepGuideProps> = ({
                           onChange={(next) => onFilterChange(step.id, next)}
                           minBound={minBound}
                           maxBound={maxBound}
-                          minBar={minBar}
-                          maxBar={maxBar}
                           stepKey={step.componentProps?.stepKey ?? "temp"}
                         />
                       );

--- a/src/components/StepPageNumericRange.tsx
+++ b/src/components/StepPageNumericRange.tsx
@@ -32,8 +32,6 @@ type Props = {
   maxBound?: number;
   stepKey?: "temp" | "netZeroBy";
   /** Optional visible-window bounds for the slider; defaults to full domain */
-  minBar?: number;
-  maxBar?: number;
 };
 
 const StepPageNumericRange: React.FC<Props> = ({
@@ -44,8 +42,6 @@ const StepPageNumericRange: React.FC<Props> = ({
   minBound = 0,
   maxBound = 6,
   stepKey = "temp",
-  minBar,
-  maxBar,
 }) => {
   const step = getStep(stepKey);
 
@@ -61,8 +57,6 @@ const StepPageNumericRange: React.FC<Props> = ({
           label={title}
           minBound={minBound}
           maxBound={maxBound}
-          minBar={minBar ?? minBound}
-          maxBar={maxBar ?? maxBound}
           step={step}
           value={value}
           onChange={onChange}


### PR DESCRIPTION
remove `minBar`/`maxBar` parameters from slider (restore same behavior as dropdown with those falling on the `*Bound` params).