### PR TITLE
feat: reorder pathway types

### DIFF
--- a/src/components/StepByStepGuide.tsx
+++ b/src/components/StepByStepGuide.tsx
@@ -127,7 +127,18 @@ const StepByStepGuide: React.FC<StepByStepGuideProps> = ({
       icon: <GitFork className="h-8 w-8" />,
       multi: false,
       componentId: "discrete",
-      options: optionsByFacet["pathwayType"].map((o) => ({
+      options: [
+        ...optionsByFacet["pathwayType"].filter(
+          (o) => o.title === "Predictive",
+        ),
+        ...optionsByFacet["pathwayType"].filter(
+          (o) => o.title === "Exploratory",
+        ),
+        ...optionsByFacet["pathwayType"].filter((o) => o.title === "Normative"),
+        ...optionsByFacet["pathwayType"].filter(
+          (o) => o.title === "Direct Policy",
+        ),
+      ].map((o) => ({
         ...o,
         description: descriptions["pathwayType"][o.title] || undefined,
       })),

--- a/src/components/StepByStepGuide.tsx
+++ b/src/components/StepByStepGuide.tsx
@@ -119,6 +119,10 @@ const StepByStepGuide: React.FC<StepByStepGuideProps> = ({
       multi: false,
       componentId: "discrete",
       options: optionsByFacet["pathwayType"]
+        .map((o) => ({
+          ...o,
+          description: descriptions["pathwayType"][o.title] || undefined,
+        }))
         .sort((a, b) => {
           const order = [
             "Predictive",
@@ -132,11 +136,7 @@ const StepByStepGuide: React.FC<StepByStepGuideProps> = ({
             (indexA === -1 ? Infinity : indexA) -
             (indexB === -1 ? Infinity : indexB)
           );
-        })
-        .map((o) => ({
-          ...o,
-          description: descriptions["pathwayType"][o.title] || undefined,
-        })),
+        }),
     },
     {
       id: "modelTempIncrease",

--- a/src/components/StepByStepGuide.tsx
+++ b/src/components/StepByStepGuide.tsx
@@ -13,6 +13,7 @@ import {
 import { SearchFilters } from "../types";
 import { pathwayMetadata } from "../data/pathwayMetadata";
 import { getGlobalFacetOptions } from "../utils/searchUtils";
+import { sortPathwayType } from "../utils/sortUtils";
 import { StepPageDiscrete, StepOption } from "./StepPage";
 import StepPageRemap, { RemapCategory } from "./StepPageRemap";
 import StepPageNumericRange from "./StepPageNumericRange";
@@ -118,25 +119,12 @@ const StepByStepGuide: React.FC<StepByStepGuideProps> = ({
       icon: <GitFork className="h-8 w-8" />,
       multi: false,
       componentId: "discrete",
-      options: optionsByFacet["pathwayType"]
-        .map((o) => ({
+      options: sortPathwayType(
+        optionsByFacet["pathwayType"].map((o) => ({
           ...o,
           description: descriptions["pathwayType"][o.title] || undefined,
-        }))
-        .sort((a, b) => {
-          const order = [
-            "Predictive",
-            "Exploratory",
-            "Normative",
-            "Direct Policy",
-          ];
-          const indexA = order.indexOf(a.title);
-          const indexB = order.indexOf(b.title);
-          return (
-            (indexA === -1 ? Infinity : indexA) -
-            (indexB === -1 ? Infinity : indexB)
-          );
-        }),
+        })),
+      ),
     },
     {
       id: "modelTempIncrease",

--- a/src/components/StepByStepGuide.tsx
+++ b/src/components/StepByStepGuide.tsx
@@ -127,21 +127,25 @@ const StepByStepGuide: React.FC<StepByStepGuideProps> = ({
       icon: <GitFork className="h-8 w-8" />,
       multi: false,
       componentId: "discrete",
-      options: [
-        ...optionsByFacet["pathwayType"].filter(
-          (o) => o.title === "Predictive",
-        ),
-        ...optionsByFacet["pathwayType"].filter(
-          (o) => o.title === "Exploratory",
-        ),
-        ...optionsByFacet["pathwayType"].filter((o) => o.title === "Normative"),
-        ...optionsByFacet["pathwayType"].filter(
-          (o) => o.title === "Direct Policy",
-        ),
-      ].map((o) => ({
-        ...o,
-        description: descriptions["pathwayType"][o.title] || undefined,
-      })),
+      options: optionsByFacet["pathwayType"]
+        .sort((a, b) => {
+          const order = [
+            "Predictive",
+            "Exploratory",
+            "Normative",
+            "Direct Policy",
+          ];
+          const indexA = order.indexOf(a.title);
+          const indexB = order.indexOf(b.title);
+          return (
+            (indexA === -1 ? Infinity : indexA) -
+            (indexB === -1 ? Infinity : indexB)
+          );
+        })
+        .map((o) => ({
+          ...o,
+          description: descriptions["pathwayType"][o.title] || undefined,
+        })),
     },
     {
       id: "modelTempIncrease",

--- a/src/utils/searchUtils.test.tsx
+++ b/src/utils/searchUtils.test.tsx
@@ -490,6 +490,15 @@ describe("getGlobalFacetOptions", () => {
     );
     // metrics: flattened set from all pathways
     expect(metricOptions.length).toBeGreaterThan(0);
+
+    // pathwayTypeOptions should be in expected order
+    const pathwayTypeLabels = pathwayTypeOptions.map((opt) => opt.label);
+    expect(pathwayTypeLabels.slice(0, 4)).toEqual([
+      "Predictive",
+      "Exploratory",
+      "Normative",
+      "Direct Policy",
+    ]);
   });
 
   it("includes 'None' ABSENT option for sectors/geography when missing in data", () => {

--- a/src/utils/searchUtils.ts
+++ b/src/utils/searchUtils.ts
@@ -7,6 +7,7 @@ import {
 import { matchesOptionalFacetAny, matchesOptionalFacetAll } from "./facets";
 import { ABSENT_FILTER_TOKEN } from "./absent";
 import { buildOptionsFromValues, hasAbsent, withAbsentOption } from "./facets";
+import { sortPathwayType } from "./sortUtils";
 import type { LabeledOption } from "./facets";
 import { index } from "../data/index.gen";
 
@@ -17,25 +18,15 @@ import { index } from "../data/index.gen";
 // ───────────────────────────────────────────────────────────────────────────────
 export function getGlobalFacetOptions(pathways: PathwayMetadataType[]) {
   // Pathway Type
-  // Reorder pathwayType options: Predictive, Exploratory, Normative, Direct Policy
+  // Use sortPathwayType to order pathwayType options
   const rawPathwayTypes = pathways.map((d) => d.pathwayType);
-  const orderedTypes = [
-    "Predictive",
-    "Exploratory",
-    "Normative",
-    "Direct Policy",
-  ];
   const pathwayTypeOptionsUnsorted = buildOptionsFromValues(rawPathwayTypes);
-  const pathwayTypeOptions = [
-    ...orderedTypes
-      .map((type) =>
-        pathwayTypeOptionsUnsorted.find((opt) => opt.label === type),
-      )
-      .filter(Boolean),
-    ...pathwayTypeOptionsUnsorted.filter(
-      (opt) => !orderedTypes.includes(opt.label),
-    ),
-  ];
+  const pathwayTypeOptions = sortPathwayType(
+    pathwayTypeOptionsUnsorted.map((opt) => ({
+      ...opt,
+      title: opt.label,
+    })),
+  ).map(({ value, label }) => ({ value, label }));
 
   // Net Zero Year
   const modelYearNetzeroOptions = buildOptionsFromValues(

--- a/src/utils/searchUtils.ts
+++ b/src/utils/searchUtils.ts
@@ -28,10 +28,12 @@ export function getGlobalFacetOptions(pathways: PathwayMetadataType[]) {
   const pathwayTypeOptionsUnsorted = buildOptionsFromValues(rawPathwayTypes);
   const pathwayTypeOptions = [
     ...orderedTypes
-      .map((type) => pathwayTypeOptionsUnsorted.find((opt) => opt.label === type))
+      .map((type) =>
+        pathwayTypeOptionsUnsorted.find((opt) => opt.label === type),
+      )
       .filter(Boolean),
     ...pathwayTypeOptionsUnsorted.filter(
-      (opt) => !orderedTypes.includes(opt.label)
+      (opt) => !orderedTypes.includes(opt.label),
     ),
   ];
 

--- a/src/utils/searchUtils.ts
+++ b/src/utils/searchUtils.ts
@@ -17,9 +17,18 @@ import { index } from "../data/index.gen";
 // ───────────────────────────────────────────────────────────────────────────────
 export function getGlobalFacetOptions(pathways: PathwayMetadataType[]) {
   // Pathway Type
-  const pathwayTypeOptions = buildOptionsFromValues(
-    pathways.map((d) => d.pathwayType),
-  );
+  // Reorder pathwayType options: Predictive, Exploratory, Normative, Direct Policy
+  const rawPathwayTypes = pathways.map((d) => d.pathwayType);
+  const orderedTypes = [
+    "Predictive",
+    "Exploratory",
+    "Normative",
+    "Direct Policy",
+  ];
+  const pathwayTypeOptionsUnsorted = buildOptionsFromValues(rawPathwayTypes);
+  const pathwayTypeOptions = orderedTypes
+    .map((type) => pathwayTypeOptionsUnsorted.find((opt) => opt.label === type))
+    .filter(Boolean);
 
   // Net Zero Year
   const modelYearNetzeroOptions = buildOptionsFromValues(

--- a/src/utils/searchUtils.ts
+++ b/src/utils/searchUtils.ts
@@ -26,9 +26,14 @@ export function getGlobalFacetOptions(pathways: PathwayMetadataType[]) {
     "Direct Policy",
   ];
   const pathwayTypeOptionsUnsorted = buildOptionsFromValues(rawPathwayTypes);
-  const pathwayTypeOptions = orderedTypes
-    .map((type) => pathwayTypeOptionsUnsorted.find((opt) => opt.label === type))
-    .filter(Boolean);
+  const pathwayTypeOptions = [
+    ...orderedTypes
+      .map((type) => pathwayTypeOptionsUnsorted.find((opt) => opt.label === type))
+      .filter(Boolean),
+    ...pathwayTypeOptionsUnsorted.filter(
+      (opt) => !orderedTypes.includes(opt.label)
+    ),
+  ];
 
   // Net Zero Year
   const modelYearNetzeroOptions = buildOptionsFromValues(

--- a/src/utils/sortUtils.test.tsx
+++ b/src/utils/sortUtils.test.tsx
@@ -1,5 +1,56 @@
 import { describe, it, expect } from "vitest";
-import { prioritizeGeographies } from "../utils/sortUtils";
+import { prioritizeGeographies, sortPathwayType } from "../utils/sortUtils";
+describe("sortPathwayType", () => {
+  it("sorts pathway types according to pathwayTypeOrder", () => {
+    const arr = [
+      { title: "Normative" },
+      { title: "Predictive" },
+      { title: "Direct Policy" },
+      { title: "Exploratory" },
+    ];
+    const sorted = sortPathwayType(arr);
+    expect(sorted.map((x) => x.title)).toEqual([
+      "Predictive",
+      "Exploratory",
+      "Normative",
+      "Direct Policy",
+    ]);
+  });
+
+  it("sorts unknown pathway types to the end", () => {
+    const arr = [
+      { title: "Normative" },
+      { title: "UnknownType" },
+      { title: "Predictive" },
+      { title: "Direct Policy" },
+    ];
+    const sorted = sortPathwayType(arr);
+    expect(sorted.map((x) => x.title)).toEqual([
+      "Predictive",
+      "Normative",
+      "Direct Policy",
+      "UnknownType",
+    ]);
+    // UnknownType is last
+    expect(sorted[sorted.length - 1].title).toBe("UnknownType");
+  });
+
+  it("returns empty array when input is empty", () => {
+    expect(sortPathwayType([])).toEqual([]);
+  });
+
+  it("does not mutate the original array", () => {
+    const arr = [
+      { title: "Normative" },
+      { title: "Predictive" },
+      { title: "Direct Policy" },
+      { title: "Exploratory" },
+    ];
+    const arrCopy = [...arr];
+    sortPathwayType(arr);
+    expect(arr).toEqual(arrCopy);
+  });
+});
 
 describe("prioritizeGeographies", () => {
   it("moves CN to front for 'China' or 'CN'", () => {

--- a/src/utils/sortUtils.ts
+++ b/src/utils/sortUtils.ts
@@ -41,3 +41,21 @@ export const prioritizeGeographies = (
   }
   return [...matched, ...rest]; // preserve relative order within each bucket
 };
+
+// Utility for sorting pathway types according to a fixed order
+export const pathwayTypeOrder = [
+  "Predictive",
+  "Exploratory",
+  "Normative",
+  "Direct Policy",
+];
+
+export function sortPathwayType<T extends { title: string }>(arr: T[]): T[] {
+  return arr.slice().sort((a, b) => {
+    const indexA = pathwayTypeOrder.indexOf(a.title);
+    const indexB = pathwayTypeOrder.indexOf(b.title);
+    return (
+      (indexA === -1 ? Infinity : indexA) - (indexB === -1 ? Infinity : indexB)
+    );
+  });
+}


### PR DESCRIPTION
closes https://rmi1.atlassian.net/browse/PBTAR-170

- reorders the pathway types in the step-by-step guide and in the dropdown filter as follows: "Predictive", "Exploratory", "Normative", "Direct Policy"
- this is a more adequate order as the first three options are all model-based options and have an implied hierarchy
- it also leads to an option ("Predictive") with currently 6 results to being the first option, rather than one with only 3 results ("Direct Policy")