### PR TITLE
build(semantic): remove `npm` SemRel config

### DIFF
--- a/package.json
+++ b/package.json
@@ -200,13 +200,6 @@
         }
       ],
       [
-        "@semantic-release/npm",
-        {
-          "npmPublish": false,
-          "tarballDir": "dist"
-        }
-      ],
-      [
         "@semantic-release/exec",
         {
           "prepareCmd": "npm run prepare:tarball"


### PR DESCRIPTION
we're not using the npm registry, so it's not relevant, and including it is pulling in the `node-tar` dependency transitively

(hopefully) closes https://github.com/RMI/pbtar/security/dependabot/8
This should also close https://github.com/RMI/pbtar/security/dependabot/11 and https://github.com/RMI/pbtar/security/dependabot/12 