### PR TITLE
shift stats to search bar (PBTAR-148)

### DIFF
--- a/src/components/SearchSection.test.tsx
+++ b/src/components/SearchSection.test.tsx
@@ -183,23 +183,45 @@ describe("SearchSection", () => {
   });
 
   describe("Clear all filters button (inline with summary)", () => {
-    it("renders the inline button when any filter is applied and calls onClear", () => {
+    it("renders the summary and clear button together when any filter is applied and calls onClear", () => {
       const props = {
         ...defaultProps,
         filters: { ...defaultProps.filters, geography: ["Europe"] },
       };
       render(<SearchSection {...props} />);
 
-      // Button should be present and visually near the summary (inline within the same <p>)
-      const paragraph = screen.getByText(/Found \d+ pathways/i).closest("p");
-      expect(paragraph).toBeTruthy();
+      // There are two matches: placeholder (aria-hidden) + visible summary.
+      const allSummaries = screen.getAllByText(/Found \d+ pathways/i);
+      const visibleSummary = allSummaries.find(
+        (el) => !el.closest('[aria-hidden="true"]'),
+      );
+
+      expect(visibleSummary).toBeDefined();
+
       const clearBtn = screen.getByTestId("clear-all-filters");
       expect(clearBtn).toBeInTheDocument();
-      // Ensure the button is inside the same paragraph node (inline placement)
-      expect(paragraph?.contains(clearBtn)).toBe(true);
+
+      // Visible summary and clear button share a container (the overlay grid div)
+      const container = visibleSummary?.closest("div");
+      expect(container).not.toBeNull();
+      expect(container?.contains(clearBtn)).toBe(true);
 
       clearBtn.click();
       expect(defaultProps.onClear).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not render visible summary or clear button when no filters are applied", () => {
+      render(<SearchSection {...defaultProps} />);
+
+      const visibleSummaries = screen
+        .queryAllByText(/Found \d+ pathways/i)
+        .filter((el) => !el.closest('[aria-hidden="true"]'));
+
+      // Only placeholder should exist; no visible summary
+      expect(visibleSummaries).toHaveLength(0);
+
+      // Clear button should not be rendered at all
+      expect(screen.queryByTestId("clear-all-filters")).not.toBeInTheDocument();
     });
 
     it("Temperature use range panels (no ANY/ALL), with 'include absent' checkbox", async () => {

--- a/src/components/SearchSection.test.tsx
+++ b/src/components/SearchSection.test.tsx
@@ -183,13 +183,6 @@ describe("SearchSection", () => {
   });
 
   describe("Clear all filters button (inline with summary)", () => {
-    it("does not render the button when no filters are applied", () => {
-      render(<SearchSection {...defaultProps} />);
-      expect(screen.queryByTestId("clear-all-filters")).toBeNull();
-      // Summary still renders
-      expect(screen.getByText(/Found 2 pathways/i)).toBeInTheDocument();
-    });
-
     it("renders the inline button when any filter is applied and calls onClear", () => {
       const props = {
         ...defaultProps,

--- a/src/components/SearchSection.tsx
+++ b/src/components/SearchSection.tsx
@@ -93,7 +93,7 @@ const SearchSection: React.FC<SearchSectionProps> = ({
           <button
             type="button"
             aria-label="Clear all filters"
-            className="ml-2 text-xs px-2 py-1 rounded border border-gray-200 bg-white text-indigo-600 hover:bg-gray-50 hover:underline focus:outline-none focus:ring-2 focus:ring-indigo-500 transition"
+            className="ml-2 text-xs px-2 py-1 rounded border border-gray-200 bg-white text-energy-700 hover:bg-gray-50 hover:underline focus:outline-none focus:ring-2 focus:ring-indigo-500 transition"
             onClick={onClear}
             data-testid="clear-all-filters"
           >

--- a/src/components/SearchSection.tsx
+++ b/src/components/SearchSection.tsx
@@ -118,7 +118,6 @@ const SearchSection: React.FC<SearchSectionProps> = ({
               {/* Left spacer (takes up remaining space to allow centering) */}
               <div></div>
 
-              {/* Centered summary */}
               <span className="text-sm text-rmigray-500 text-center">
                 Found {pathwaysNumber} pathways
               </span>

--- a/src/components/SearchSection.tsx
+++ b/src/components/SearchSection.tsx
@@ -77,13 +77,29 @@ const SearchSection: React.FC<SearchSectionProps> = ({
 
   return (
     <div className="bg-gray-50">
-      <div className="mb-4 pt-8">
-        <SearchBox
-          value={filters.searchTerm}
-          onChange={(value) => onFilterChange("searchTerm", value)}
-          onSearch={onSearch}
-          onClear={onClear}
-        />
+      <div className="flex items-center gap-4 pt-8 mb-4">
+        <div className="flex-1">
+          <SearchBox
+            value={filters.searchTerm}
+            onChange={(value) => onFilterChange("searchTerm", value)}
+            onSearch={onSearch}
+            onClear={onClear}
+          />
+        </div>
+        <div className="flex items-center gap-2 whitespace-nowrap">
+          <span className="text-sm text-rmigray-500 relative">
+            Found {pathwaysNumber} pathways
+          </span>
+          <button
+            type="button"
+            aria-label="Clear all filters"
+            className="ml-2 text-xs px-2 py-1 rounded border border-gray-200 bg-white text-indigo-600 hover:bg-gray-50 hover:underline focus:outline-none focus:ring-2 focus:ring-indigo-500 transition"
+            onClick={onClear}
+            data-testid="clear-all-filters"
+          >
+            Reset filters
+          </button>
+        </div>
       </div>
       <div className="grid gap-2 grid-cols-[repeat(auto-fit,minmax(12rem,1fr))]">
         <div>
@@ -164,23 +180,6 @@ const SearchSection: React.FC<SearchSectionProps> = ({
             menuWidthClassName="w-60"
           />
         </div>
-      </div>
-      <div className="mt-4 ml-1 flex items-center justify-between gap-3">
-        <p className="text-sm text-rmigray-500">
-          Found {pathwaysNumber} pathways
-          {areFiltersApplied && " matching your criteria"}
-          {areFiltersApplied && (
-            <button
-              type="button"
-              aria-label="Clear all filters"
-              className="ml-2 text-sm text-indigo-600 hover:underline focus:outline-none focus:ring-2 focus:ring-indigo-500 rounded"
-              onClick={onClear}
-              data-testid="clear-all-filters"
-            >
-              Clear all filters
-            </button>
-          )}
-        </p>
       </div>
     </div>
   );

--- a/src/components/SearchSection.tsx
+++ b/src/components/SearchSection.tsx
@@ -86,19 +86,41 @@ const SearchSection: React.FC<SearchSectionProps> = ({
             onClear={onClear}
           />
         </div>
-        <div className="flex items-center gap-2 whitespace-nowrap">
-          <span className="text-sm text-rmigray-500 relative">
-            Found {pathwaysNumber} pathways
-          </span>
-          <button
-            type="button"
-            aria-label="Clear all filters"
-            className="ml-2 text-xs px-2 py-1 rounded border border-gray-200 bg-white text-energy-700 hover:bg-gray-50 hover:underline focus:outline-none focus:ring-2 focus:ring-indigo-500 transition"
-            onClick={onClear}
-            data-testid="clear-all-filters"
+
+        {/* Reserve fixed space so layout doesn't shift as filters / counts change */}
+        <div className="relative flex items-center whitespace-nowrap">
+          {/* Invisible placeholder: defines the max width + height of this area */}
+          <div
+            className="invisible flex items-center gap-2"
+            aria-hidden="true"
           >
-            Reset filters
-          </button>
+            {/* Use a "wide" example so width doesn't change when the number shrinks */}
+            <span className="text-sm text-rmigray-500">Found 888 pathways</span>
+            <button
+              type="button"
+              className="ml-2 text-xs px-2 py-1 rounded border border-gray-200 bg-white text-energy-700"
+            >
+              Reset filters
+            </button>
+          </div>
+
+          {/* Actual visible content, absolutely positioned over the placeholder */}
+          {areFiltersApplied && (
+            <div className="absolute inset-0 flex items-center gap-2">
+              <span className="text-sm text-rmigray-500">
+                Found {pathwaysNumber} pathways
+              </span>
+              <button
+                type="button"
+                aria-label="Clear all filters"
+                className="ml-2 text-xs px-2 py-1 rounded border border-gray-200 bg-white text-energy-700 hover:bg-gray-50 hover:underline focus:outline-none focus:ring-2 focus:ring-indigo-500 transition"
+                onClick={onClear}
+                data-testid="clear-all-filters"
+              >
+                Reset filters
+              </button>
+            </div>
+          )}
         </div>
       </div>
       <div className="grid gap-2 grid-cols-[repeat(auto-fit,minmax(12rem,1fr))]">

--- a/src/components/SearchSection.tsx
+++ b/src/components/SearchSection.tsx
@@ -77,7 +77,7 @@ const SearchSection: React.FC<SearchSectionProps> = ({
 
   return (
     <div className="bg-gray-50">
-      <div className="flex items-center gap-4 pt-8 mb-4">
+      <div className="flex items-center pt-8 mb-4">
         <div className="flex-1">
           <SearchBox
             value={filters.searchTerm}
@@ -88,14 +88,14 @@ const SearchSection: React.FC<SearchSectionProps> = ({
         </div>
 
         {/* Reserve fixed space so layout doesn't shift as filters / counts change */}
-        <div className="relative flex items-center whitespace-nowrap">
+        <div className="relative">
           {/* Invisible placeholder: defines the max width + height of this area */}
           <div
             className="invisible flex items-center gap-2"
             aria-hidden="true"
           >
             {/* Use a "wide" example so width doesn't change when the number shrinks */}
-            <span className="text-sm text-rmigray-500">Found 888 pathways</span>
+            <span className="text-sm">Found 888 pathways</span>
             <button
               type="button"
               className="ml-2 text-xs px-2 py-1 rounded border border-gray-200 bg-white text-energy-700"
@@ -106,14 +106,31 @@ const SearchSection: React.FC<SearchSectionProps> = ({
 
           {/* Actual visible content, absolutely positioned over the placeholder */}
           {areFiltersApplied && (
-            <div className="absolute inset-0 flex items-center gap-2">
-              <span className="text-sm text-rmigray-500">
+            <div
+              className="
+                absolute inset-0 
+                grid 
+                grid-cols-[1fr_auto_auto] 
+                items-center 
+                w-full
+              "
+            >
+              {/* Left spacer (takes up remaining space to allow centering) */}
+              <div></div>
+
+              {/* Centered summary */}
+              <span className="text-sm text-rmigray-500 text-center">
                 Found {pathwaysNumber} pathways
               </span>
               <button
                 type="button"
                 aria-label="Clear all filters"
-                className="ml-2 text-xs px-2 py-1 rounded border border-gray-200 bg-white text-energy-700 hover:bg-gray-50 hover:underline focus:outline-none focus:ring-2 focus:ring-indigo-500 transition"
+                className="
+                  ml-2 text-xs px-2 py-1 rounded border border-gray-200 
+                  bg-white text-energy-700 hover:bg-gray-50 hover:underline 
+                  focus:outline-none focus:ring-2 focus:ring-indigo-500 
+                  transition
+                "
                 onClick={onClear}
                 data-testid="clear-all-filters"
               >

--- a/src/components/SearchSection.tsx
+++ b/src/components/SearchSection.tsx
@@ -91,7 +91,7 @@ const SearchSection: React.FC<SearchSectionProps> = ({
         <div className="relative">
           {/* Invisible placeholder: defines the max width + height of this area */}
           <div
-            className="invisible flex items-center gap-2"
+            className="invisible flex items-center"
             aria-hidden="true"
           >
             {/* Use a "wide" example so width doesn't change when the number shrinks */}


### PR DESCRIPTION
Cleanup of work started by @jdhoffa.

Move "found XX pathways" and reset button to inline with string search input, and hide (invisible) when no filters are applied. Reserves space so search box doesn't resize when filter is applied.