### PR TITLE
SBS Navigation updates (PBTAR-145) (ALT)

### DIFF
--- a/src/components/StepByStepGuide.tsx
+++ b/src/components/StepByStepGuide.tsx
@@ -384,7 +384,7 @@ const StepByStepGuide: React.FC<StepByStepGuideProps> = ({
                         <button
                           key={index}
                           onClick={() => setCurrentView(index)}
-                          className={`w-2 h-2 rounded-full ${currentView === index ? "bg-energy" : "bg-gray-300"}`}
+                          className={`w-4 h-4 rounded-full ${currentView === index ? "bg-energy" : "bg-gray-300"} p-1`}
                         />
                       ))}
                     </div>

--- a/src/components/StepByStepGuide.tsx
+++ b/src/components/StepByStepGuide.tsx
@@ -391,12 +391,6 @@ const StepByStepGuide: React.FC<StepByStepGuideProps> = ({
 
                     <div className="flex items-center space-x-4">
                       <button
-                        onClick={() => setCurrentView("home")}
-                        className="p-2 hover:text-energy"
-                      >
-                        <Home className="h-5 w-5" />
-                      </button>
-                      <button
                         onClick={() =>
                           setCurrentView(Math.max(0, currentView - 1))
                         }
@@ -404,6 +398,12 @@ const StepByStepGuide: React.FC<StepByStepGuideProps> = ({
                         className="p-2 hover:text-energy disabled:opacity-50"
                       >
                         <ChevronLeft className="h-5 w-5" />
+                      </button>
+                      <button
+                        onClick={() => setCurrentView("home")}
+                        className="p-2 hover:text-energy"
+                      >
+                        <Home className="h-5 w-5" />
                       </button>
                       <button
                         onClick={() =>

--- a/src/components/StepByStepGuide.tsx
+++ b/src/components/StepByStepGuide.tsx
@@ -379,31 +379,32 @@ const StepByStepGuide: React.FC<StepByStepGuideProps> = ({
                   })()}
 
                   <div className="grid grid-cols-3 items-center mt-6">
-                    <div className="flex space-x-2 justify-start">
-                      {steps.map((_, index) => (
-                        <button
-                          key={index}
-                          onClick={() => setCurrentView(index)}
-                          className={`w-4 h-4 rounded-full ${currentView === index ? "bg-energy" : "bg-gray-300"} p-1`}
-                        />
-                      ))}
-                    </div>
-                    <div className="flex items-center space-x-4 justify-center">
+                    <div /> {/* Empty left column */}
+                    <div className="flex items-center justify-center">
                       <button
                         onClick={() =>
                           setCurrentView(Math.max(0, currentView - 1))
                         }
                         disabled={currentView === 0}
-                        className="p-2 hover:text-energy disabled:opacity-50"
+                        className="p-1 hover:text-energy disabled:opacity-50"
                       >
                         <ChevronLeft className="h-5 w-5" />
                       </button>
                       <button
                         onClick={() => setCurrentView("home")}
-                        className="p-2 hover:text-energy"
+                        className="p-1 text-gray-300 hover:text-energy"
                       >
                         <Home className="h-5 w-5" />
                       </button>
+                      <div className="flex space-x-2">
+                        {steps.map((_, index) => (
+                          <button
+                            key={index}
+                            onClick={() => setCurrentView(index)}
+                            className={`w-4 h-4 rounded-full ${currentView === index ? "bg-energy" : "bg-gray-300"} p-1`}
+                          />
+                        ))}
+                      </div>
                       <button
                         onClick={() =>
                           setCurrentView(
@@ -411,7 +412,7 @@ const StepByStepGuide: React.FC<StepByStepGuideProps> = ({
                           )
                         }
                         disabled={currentView === steps.length - 1}
-                        className="p-2 hover:text-energy disabled:opacity-50"
+                        className="p-1 hover:text-energy disabled:opacity-50"
                       >
                         <ChevronRight className="h-5 w-5" />
                       </button>

--- a/src/components/StepByStepGuide.tsx
+++ b/src/components/StepByStepGuide.tsx
@@ -378,8 +378,8 @@ const StepByStepGuide: React.FC<StepByStepGuideProps> = ({
                     );
                   })()}
 
-                  <div className="flex items-center justify-between mt-6">
-                    <div className="flex space-x-2">
+                  <div className="grid grid-cols-3 items-center mt-6">
+                    <div className="flex space-x-2 justify-start">
                       {steps.map((_, index) => (
                         <button
                           key={index}
@@ -388,8 +388,7 @@ const StepByStepGuide: React.FC<StepByStepGuideProps> = ({
                         />
                       ))}
                     </div>
-
-                    <div className="flex items-center space-x-4">
+                    <div className="flex items-center space-x-4 justify-center">
                       <button
                         onClick={() =>
                           setCurrentView(Math.max(0, currentView - 1))
@@ -417,6 +416,7 @@ const StepByStepGuide: React.FC<StepByStepGuideProps> = ({
                         <ChevronRight className="h-5 w-5" />
                       </button>
                     </div>
+                    <div /> {/* Empty right column */}
                   </div>
                 </div>
               )}


### PR DESCRIPTION
Alternate to #642.

* increase size of nav dots (clickable tagets)
* center nav arrows and home button
* (This PR): include nav dots between arrows (in center)

<img width="1930" height="1098" alt="Screenshot_2025-12-03_12 11 07@2x" src="https://github.com/user-attachments/assets/27bd5d35-a73e-407b-842f-e7a7c2b2b405" />