### PR TITLE
feat(detail): redesign type/year/temp UI (PBTAR-159)

### DIFF
--- a/src/components/PathwayCard.tsx
+++ b/src/components/PathwayCard.tsx
@@ -13,22 +13,12 @@ import { ChevronRight } from "lucide-react";
 import HighlightedText from "./HighlightedText";
 import { prioritizeMatches, prioritizeGeographies } from "../utils/sortUtils";
 import { getSectorTooltip, getMetricTooltip } from "../utils/tooltipUtils";
+import getTemperatureColor from "../utils/getTemperatureColor";
 
 interface PathwayCardProps {
   pathway: PathwayMetadataType;
   searchTerm?: string;
 }
-
-const getTemperatureColor = (temp: number): string => {
-  // Define temperature ranges and corresponding colors
-  // Using colors from the style guide
-  if (temp <= 1.5) return "bg-pinishgreen-100"; // Yellowish
-  if (temp <= 2.0) return "bg-solar-100";
-  if (temp <= 2.5) return "bg-solar-200";
-  if (temp <= 3.0) return "bg-rmired-100"; // Orange
-  if (temp <= 3.5) return "bg-rmired-200";
-  return "bg-rmired-400"; // Red for higher temperatures
-};
 
 const truncateText = (text: string, maxLength: number) =>
   text.length > maxLength ? text.slice(0, maxLength) + "..." : text;
@@ -194,7 +184,7 @@ const PathwayCard: React.FC<PathwayCardProps> = ({
                 <HighlightedText
                   text={truncateText(
                     pathway.publication.title.short ||
-                      pathway.publication.title.full,
+                    pathway.publication.title.full,
                     40, // <-- set your desired max length here
                   )}
                   searchTerm={searchTerm}

--- a/src/components/PathwayCard.tsx
+++ b/src/components/PathwayCard.tsx
@@ -184,7 +184,7 @@ const PathwayCard: React.FC<PathwayCardProps> = ({
                 <HighlightedText
                   text={truncateText(
                     pathway.publication.title.short ||
-                    pathway.publication.title.full,
+                      pathway.publication.title.full,
                     40, // <-- set your desired max length here
                   )}
                   searchTerm={searchTerm}

--- a/src/pages/PathwayDetailPage.tsx
+++ b/src/pages/PathwayDetailPage.tsx
@@ -29,7 +29,6 @@ import PublicationBlock from "../components/PublicationBlock";
 import { PlotSelector, TimeSeries } from "../components/PlotSelector";
 import getTemperatureColor from "../utils/getTemperatureColor";
 
-
 const PathwayDetailPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
   const [pathway, setPathway] = useState<PathwayMetadataType | null>(null);
@@ -160,9 +159,7 @@ const PathwayDetailPage: React.FC = () => {
           </h1>
 
           <div className="mt-2 space-y-4">
-            <p className="text-white">
-              {pathway.description}
-            </p>
+            <p className="text-white">{pathway.description}</p>
 
             <div className="space-y-1 inline-block">
               <div className="flex text-[10px] font-semibold text-white tracking-wider uppercase">
@@ -233,17 +230,17 @@ const PathwayDetailPage: React.FC = () => {
 
               {tsIndexLoaded && datasets.length > 0
                 ? datasets.map((d) => {
-                  const label = d.label ?? d.datasetId;
-                  const summary = summarizeSummary(d.summary);
-                  return (
-                    <DownloadDataset
-                      key={d.datasetId}
-                      label={label}
-                      href={d.path}
-                      summary={summary}
-                    />
-                  );
-                })
+                    const label = d.label ?? d.datasetId;
+                    const summary = summarizeSummary(d.summary);
+                    return (
+                      <DownloadDataset
+                        key={d.datasetId}
+                        label={label}
+                        href={d.path}
+                        summary={summary}
+                      />
+                    );
+                  })
                 : null}
             </div>
 

--- a/src/pages/PathwayDetailPage.tsx
+++ b/src/pages/PathwayDetailPage.tsx
@@ -3,7 +3,6 @@ import { useParams, Link } from "react-router-dom";
 import Markdown from "../components/Markdown";
 import { pathwayMetadata } from "../data/pathwayMetadata";
 import { PathwayMetadataType } from "../types";
-import { BadgeMaybeAbsent } from "../components/Badge";
 import BadgeArray from "../components/BadgeArray";
 import {
   geographyKind,
@@ -230,17 +229,17 @@ const PathwayDetailPage: React.FC = () => {
 
               {tsIndexLoaded && datasets.length > 0
                 ? datasets.map((d) => {
-                    const label = d.label ?? d.datasetId;
-                    const summary = summarizeSummary(d.summary);
-                    return (
-                      <DownloadDataset
-                        key={d.datasetId}
-                        label={label}
-                        href={d.path}
-                        summary={summary}
-                      />
-                    );
-                  })
+                  const label = d.label ?? d.datasetId;
+                  const summary = summarizeSummary(d.summary);
+                  return (
+                    <DownloadDataset
+                      key={d.datasetId}
+                      label={label}
+                      href={d.path}
+                      summary={summary}
+                    />
+                  );
+                })
                 : null}
             </div>
 

--- a/src/pages/PathwayDetailPage.tsx
+++ b/src/pages/PathwayDetailPage.tsx
@@ -27,6 +27,8 @@ import {
 } from "../utils/timeseriesIndex";
 import PublicationBlock from "../components/PublicationBlock";
 import { PlotSelector, TimeSeries } from "../components/PlotSelector";
+import getTemperatureColor from "../utils/getTemperatureColor";
+
 
 const PathwayDetailPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
@@ -56,6 +58,9 @@ const PathwayDetailPage: React.FC = () => {
       summary?: unknown;
     }>
   >([]);
+
+  const formatTemp = (t: number | undefined | null) =>
+    t == null ? null : `${t}°C`;
 
   useEffect(() => {
     let isMounted = true;
@@ -153,38 +158,62 @@ const PathwayDetailPage: React.FC = () => {
             {pathway.name.full +
               (pathway.name.short ? ` (${pathway.name.short})` : "")}
           </h1>
-          <p className="text-white mb-4">{pathway.description}</p>
 
-          <div className="flex flex-wrap gap-2 mb-4">
-            <BadgeMaybeAbsent
-              tooltip={getPathwayTypeTooltip(pathway.pathwayType)}
-              variant="pathwayType"
-            >
-              {pathway.pathwayType}
-            </BadgeMaybeAbsent>
-            <BadgeMaybeAbsent variant="year">
-              {pathway.modelYearNetzero}
-            </BadgeMaybeAbsent>
-            <BadgeMaybeAbsent
-              variant="temperature"
-              toLabel={(t) => {
-                const s = String(t);
-                return s.endsWith("°C") ? s : `${s}°C`;
-              }}
-            >
-              {pathway.modelTempIncrease}
-            </BadgeMaybeAbsent>
-          </div>
+          <div className="mt-2 space-y-4">
+            <p className="text-white">
+              {pathway.description}
+            </p>
 
-          <div className="flex flex-col sm:flex-row sm:justify-between text-sm">
-            <p className="mb-1 sm:mb-0">
-              <span className="text-white">Publisher:</span>{" "}
-              {pathway.publication.publisher.full}
-            </p>
-            <p>
-              <span className="text-white">Published:</span>{" "}
-              {pathway.publication.year}
-            </p>
+            <div className="space-y-1 inline-block">
+              <div className="flex text-[10px] font-semibold text-white tracking-wider uppercase">
+                <span className="w-30 text-center">Type</span>
+
+                {pathway.modelYearNetzero && (
+                  <span className="w-30 text-center">Net zero by</span>
+                )}
+
+                {typeof pathway.modelTempIncrease === "number" && (
+                  <span className="w-30 text-center">Warming by 2100</span>
+                )}
+              </div>
+
+              <div className="flex overflow-hidden rounded-full bg-neutral-100/90 text-sm font-medium text-rmigray-800 shadow-sm">
+                <span
+                  className="w-30 px-3 py-1 text-center"
+                  title={getPathwayTypeTooltip(pathway.pathwayType)}
+                >
+                  {pathway.pathwayType}
+                </span>
+
+                {pathway.modelYearNetzero && (
+                  <span className="w-30 px-3 py-1 border-l bg-rmiblue-100 border-white/60 text-center">
+                    {pathway.modelYearNetzero}
+                  </span>
+                )}
+
+                {typeof pathway.modelTempIncrease === "number" && (
+                  <span
+                    className={
+                      "w-30 px-3 py-1 border-l border-white/60 text-center " +
+                      getTemperatureColor(pathway.modelTempIncrease)
+                    }
+                  >
+                    {formatTemp(pathway.modelTempIncrease)}
+                  </span>
+                )}
+              </div>
+            </div>
+
+            <div className="flex flex-col sm:flex-row sm:items-end sm:justify-between text-xs sm:text-sm text-white gap-1">
+              <p className="sm:max-w-[60%]">
+                <span className="font-semibold">Publisher:</span>{" "}
+                {pathway.publication.publisher.full}
+              </p>
+              <p className="sm:text-right">
+                <span className="font-semibold">Published:</span>{" "}
+                {pathway.publication.year}
+              </p>
+            </div>
           </div>
         </div>
 
@@ -204,17 +233,17 @@ const PathwayDetailPage: React.FC = () => {
 
               {tsIndexLoaded && datasets.length > 0
                 ? datasets.map((d) => {
-                    const label = d.label ?? d.datasetId;
-                    const summary = summarizeSummary(d.summary);
-                    return (
-                      <DownloadDataset
-                        key={d.datasetId}
-                        label={label}
-                        href={d.path}
-                        summary={summary}
-                      />
-                    );
-                  })
+                  const label = d.label ?? d.datasetId;
+                  const summary = summarizeSummary(d.summary);
+                  return (
+                    <DownloadDataset
+                      key={d.datasetId}
+                      label={label}
+                      href={d.path}
+                      summary={summary}
+                    />
+                  );
+                })
                 : null}
             </div>
 

--- a/src/pages/PathwayDetailPage.tsx
+++ b/src/pages/PathwayDetailPage.tsx
@@ -229,17 +229,17 @@ const PathwayDetailPage: React.FC = () => {
 
               {tsIndexLoaded && datasets.length > 0
                 ? datasets.map((d) => {
-                  const label = d.label ?? d.datasetId;
-                  const summary = summarizeSummary(d.summary);
-                  return (
-                    <DownloadDataset
-                      key={d.datasetId}
-                      label={label}
-                      href={d.path}
-                      summary={summary}
-                    />
-                  );
-                })
+                    const label = d.label ?? d.datasetId;
+                    const summary = summarizeSummary(d.summary);
+                    return (
+                      <DownloadDataset
+                        key={d.datasetId}
+                        label={label}
+                        href={d.path}
+                        summary={summary}
+                      />
+                    );
+                  })
                 : null}
             </div>
 

--- a/src/utils/getTemperatureColor.ts
+++ b/src/utils/getTemperatureColor.ts
@@ -1,7 +1,7 @@
 const getTemperatureColor = (temp: number): string => {
   // Define temperature ranges and corresponding colors
   // Using colors from the style guide
-  if (temp <= 1.5) return "bg-pinishgreen-100"; // Yellowish
+  if (temp <= 1.5) return "bg-pinishgreen-100"; // Light green
   if (temp <= 2.0) return "bg-solar-100";
   if (temp <= 2.5) return "bg-solar-200";
   if (temp <= 3.0) return "bg-rmired-100"; // Orange

--- a/src/utils/getTemperatureColor.ts
+++ b/src/utils/getTemperatureColor.ts
@@ -1,0 +1,12 @@
+const getTemperatureColor = (temp: number): string => {
+    // Define temperature ranges and corresponding colors
+    // Using colors from the style guide
+    if (temp <= 1.5) return "bg-pinishgreen-100"; // Yellowish
+    if (temp <= 2.0) return "bg-solar-100";
+    if (temp <= 2.5) return "bg-solar-200";
+    if (temp <= 3.0) return "bg-rmired-100"; // Orange
+    if (temp <= 3.5) return "bg-rmired-200";
+    return "bg-rmired-400"; // Red for higher temperatures
+};
+
+export default getTemperatureColor;

--- a/src/utils/getTemperatureColor.ts
+++ b/src/utils/getTemperatureColor.ts
@@ -1,12 +1,12 @@
 const getTemperatureColor = (temp: number): string => {
-    // Define temperature ranges and corresponding colors
-    // Using colors from the style guide
-    if (temp <= 1.5) return "bg-pinishgreen-100"; // Yellowish
-    if (temp <= 2.0) return "bg-solar-100";
-    if (temp <= 2.5) return "bg-solar-200";
-    if (temp <= 3.0) return "bg-rmired-100"; // Orange
-    if (temp <= 3.5) return "bg-rmired-200";
-    return "bg-rmired-400"; // Red for higher temperatures
+  // Define temperature ranges and corresponding colors
+  // Using colors from the style guide
+  if (temp <= 1.5) return "bg-pinishgreen-100"; // Yellowish
+  if (temp <= 2.0) return "bg-solar-100";
+  if (temp <= 2.5) return "bg-solar-200";
+  if (temp <= 3.0) return "bg-rmired-100"; // Orange
+  if (temp <= 3.5) return "bg-rmired-200";
+  return "bg-rmired-400"; // Red for higher temperatures
 };
 
 export default getTemperatureColor;


### PR DESCRIPTION
Redesigns the pathway detail header section to present key attributes (type, net zero year, and warming by 2100) in a compact, labeled pill bar and temperature color coding, consistent with the `PathwayCard` UI.

Closes PBTAR-159