### PR TITLE
feat(ui): tweak sticky search bar spacing

### DIFF
--- a/src/components/SearchSection.tsx
+++ b/src/components/SearchSection.tsx
@@ -76,7 +76,7 @@ const SearchSection: React.FC<SearchSectionProps> = ({
       : filters.dataAvailability != null);
 
   return (
-    <div className="bg-gray-50">
+    <div className="bg-gray-50 pb-4">
       <div className="flex items-center pt-8 mb-4">
         <div className="flex-1">
           <SearchBox

--- a/src/pages/PathwaySearch.tsx
+++ b/src/pages/PathwaySearch.tsx
@@ -128,7 +128,7 @@ const PathwaySearch: React.FC = () => {
         className={`sticky rounded-lg top-0 z-10 bg-gray-50 inset-x-0 transition-shadow duration-200 ${isSticky ? "shadow-md" : ""}`}
         style={{ margin: "0 calc(-50vw + 50%)" }}
       >
-        <div className="container mx-auto px-4 py-2">
+        <div className="container mx-auto px-4">
           <SearchSection
             filters={filters}
             pathwaysNumber={filteredPathways.length}


### PR DESCRIPTION
Minor UI tweak to align the padding _above_ and _below_ the `SearchSection`. Note in particular the spacing between the DropDown filters and the PathwayCards. This change gives the cards a bit of breathing room.

## Before
<img width="1438" height="303" alt="Screenshot 2025-12-03 at 15 38 35" src="https://github.com/user-attachments/assets/c23276e6-be28-4d34-a164-26cfac15bfb1" />

## After
<img width="1434" height="306" alt="Screenshot 2025-12-03 at 15 39 05" src="https://github.com/user-attachments/assets/cb8d47e3-0eb4-4e11-9e0c-714e6c1d43ad" />
