### PR TITLE
feat: rename to Transition Pathways Repository PBTAR-168

### DIFF
--- a/src/components/Footer.test.tsx
+++ b/src/components/Footer.test.tsx
@@ -16,7 +16,7 @@ describe("Footer component", () => {
   it("renders the title text correctly", () => {
     renderFooter();
     expect(
-      screen.getByText("Climate Transition Pathways Repository"),
+      screen.getByText("Transition Pathways Repository"),
     ).toBeInTheDocument();
   });
 
@@ -49,7 +49,7 @@ describe("Footer component", () => {
     renderFooter();
     // Since icons don't have accessible text, we check for their parent container
     const titleSection = screen
-      .getByText("Climate Transition Pathways Repository")
+      .getByText("Transition Pathways Repository")
       .closest("div");
     expect(titleSection).toBeInTheDocument();
     // We can check that the SVG is present (assuming BarChart3 renders as SVG)

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -13,7 +13,7 @@ const Footer: React.FC = () => {
               className="text-white mr-2"
             />
             <span className="text-sm font-medium text-white">
-              Climate Transition Pathways Repository
+              Transition Pathways Repository
             </span>
           </div>
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -16,7 +16,7 @@ const Header: React.FC = () => {
           />
           <div>
             <h1 className="text-xl md:text-2xl font-bold tracking-tight">
-              Climate Transition Pathways Repository
+              Transition Pathways Repository
             </h1>
             <p className="text-xs md:text-sm text-white">by RMI</p>
           </div>

--- a/src/pages/AboutPage.test.tsx
+++ b/src/pages/AboutPage.test.tsx
@@ -17,7 +17,7 @@ describe("AboutPage component", () => {
     renderAboutPage();
     // Assuming your AboutPage has a site title text
     expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
-      "About the Climate Transition Pathways Repository",
+      "About the Transition Pathways Repository",
     );
   });
 
@@ -124,7 +124,7 @@ describe("AboutPage component", () => {
     it("uses container class for layout", () => {
       renderAboutPage();
       const container = screen
-        .getByText("About the Climate Transition Pathways Repository")
+        .getByText("About the Transition Pathways Repository")
         .closest("div.container");
       expect(container).toBeInTheDocument();
     });

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -15,9 +15,9 @@ const AboutPage: React.FC = () => {
             Purpose
           </h2>
           <p className="text-rmigray-700 mb-4">
-            The Transition Pathways Repository is designed to help
-            financial institutions efficiently discover, compare, and utilize
-            diverse climate transition pathways for their assessments.
+            The Transition Pathways Repository is designed to help financial
+            institutions efficiently discover, compare, and utilize diverse
+            climate transition pathways for their assessments.
           </p>
           <p className="text-rmigray-700 mb-4">
             Our goal is to simplify the process of finding relevant pathways and

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -7,7 +7,7 @@ const AboutPage: React.FC = () => {
     <div className="container mx-auto px-4 py-8">
       <div className="max-w-4xl mx-auto">
         <h1 className="text-3xl font-bold text-rmigray-800 mb-6">
-          About the Climate Transition Pathways Repository
+          About the Transition Pathways Repository
         </h1>
 
         <section className="bg-white rounded-lg shadow-md p-6 mb-8">
@@ -15,7 +15,7 @@ const AboutPage: React.FC = () => {
             Purpose
           </h2>
           <p className="text-rmigray-700 mb-4">
-            The Climate Transition Pathways Repository is designed to help
+            The Transition Pathways Repository is designed to help
             financial institutions efficiently discover, compare, and utilize
             diverse climate transition pathways for their assessments.
           </p>


### PR DESCRIPTION
As per decision from CF, we are going with "Transition Pathways Repository" as opposed to "Climate Transition Pathways Repository"

Closes PBTAR-168