### PR TITLE
feat(pathways): redesign key features with grouped, typed visual components

### DIFF
--- a/src/components/KeyFeatures.test.tsx
+++ b/src/components/KeyFeatures.test.tsx
@@ -86,4 +86,38 @@ describe("KeyFeatures", () => {
     expect(label).toHaveClass("text-rmigray-500");
     expect(label).not.toHaveClass("bg-rmiblue-100");
   });
+
+  it("applies horizontal divider classes to bottom-row groups only", () => {
+    render(<KeyFeatures keyFeatures={mockKeyFeatures} />);
+    const groups = screen
+      .getAllByRole("heading", { level: 4 })
+      .map((h) => h.parentElement as HTMLElement);
+
+    // top row — no border-t
+    expect(groups[0]).not.toHaveClass("border-t");
+    expect(groups[1]).not.toHaveClass("border-t");
+    // bottom row — border-t present
+    expect(groups[2]).toHaveClass("border-t");
+    expect(groups[3]).toHaveClass("border-t");
+  });
+
+  it("does not render old box styling on any group", () => {
+    render(<KeyFeatures keyFeatures={mockKeyFeatures} />);
+    const groups = screen
+      .getAllByRole("heading", { level: 4 })
+      .map((h) => h.parentElement as HTMLElement);
+
+    groups.forEach((g) => {
+      expect(g).not.toHaveClass("bg-white");
+      expect(g).not.toHaveClass("rounded-md");
+    });
+  });
+
+  it("renders without crashing when a feature value is missing", () => {
+    const sparse = {
+      ...mockKeyFeatures,
+      emissionsScope: undefined,
+    } as PathwayMetadataType["keyFeatures"];
+    expect(() => render(<KeyFeatures keyFeatures={sparse} />)).not.toThrow();
+  });
 });

--- a/src/components/KeyFeatures.test.tsx
+++ b/src/components/KeyFeatures.test.tsx
@@ -27,7 +27,9 @@ describe("KeyFeatures", () => {
       screen.getByText("Energy System & Transition Levers"),
     ).toBeInTheDocument();
     expect(screen.getByText("Policy Environment")).toBeInTheDocument();
-    expect(screen.getByText("Technology Assumptions")).toBeInTheDocument();
+    expect(
+      screen.getByText("Technology & Feasibility Assumptions"),
+    ).toBeInTheDocument();
   });
 
   it("single-select: selected pill has blue classes, unselected have neutral classes", () => {

--- a/src/components/KeyFeatures.test.tsx
+++ b/src/components/KeyFeatures.test.tsx
@@ -119,7 +119,7 @@ describe("KeyFeatures", () => {
     const sparse = {
       ...mockKeyFeatures,
       emissionsScope: undefined,
-    } as PathwayMetadataType["keyFeatures"];
+    } as unknown as PathwayMetadataType["keyFeatures"];
     expect(() => render(<KeyFeatures keyFeatures={sparse} />)).not.toThrow();
   });
 });

--- a/src/components/KeyFeatures.test.tsx
+++ b/src/components/KeyFeatures.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import KeyFeatures from "./KeyFeatures";
+import type { PathwayMetadataType } from "../types";
+
+const mockKeyFeatures: PathwayMetadataType["keyFeatures"] = {
+  emissionsScope: "CO2",
+  emissionsTrajectory: "Moderate decrease",
+  energyEfficiency: "Minor improvement",
+  energyDemand: "Low or no change",
+  electrification: "Moderate increase",
+  policyTypes: ["Carbon price", "Subsidies"],
+  policyAmbition: "NDCs incl. conditional targets",
+  newTechnologiesIncluded: ["CCUS", "Battery storage"],
+  technologyCostTrend: "Decrease",
+  technologyCostsDetail: "Total costs",
+  investmentNeeds: "By technology",
+};
+
+describe("KeyFeatures", () => {
+  it("renders all four group headers", () => {
+    render(<KeyFeatures keyFeatures={mockKeyFeatures} />);
+    expect(
+      screen.getByText("Emissions Boundary & Trajectory"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Energy System & Transition Levers"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Policy Environment")).toBeInTheDocument();
+    expect(screen.getByText("Technology Assumptions")).toBeInTheDocument();
+  });
+
+  it("single-select: selected pill has blue classes, unselected have neutral classes", () => {
+    render(<KeyFeatures keyFeatures={mockKeyFeatures} />);
+
+    // "CO2" is selected for emissionsScope
+    const selected = screen.getByText("CO2").closest("span") as HTMLElement;
+    expect(selected).toHaveClass("bg-rmiblue-100");
+    expect(selected).toHaveClass("text-rmiblue-800");
+
+    // "CO2e (Kyoto)" is not selected
+    const unselected = screen
+      .getByText("CO2e (Kyoto)")
+      .closest("span") as HTMLElement;
+    expect(unselected).toHaveClass("bg-neutral-50");
+    expect(unselected).toHaveClass("text-neutral-400");
+    expect(unselected).not.toHaveClass("bg-rmiblue-100");
+  });
+
+  it("multi-select: all selected pills have blue classes, unselected have neutral classes", () => {
+    render(<KeyFeatures keyFeatures={mockKeyFeatures} />);
+
+    // "Carbon price" and "Subsidies" are selected for policyTypes
+    const carbonPrice = screen
+      .getByText("Carbon price")
+      .closest("span") as HTMLElement;
+    expect(carbonPrice).toHaveClass("bg-rmiblue-100");
+
+    const subsidies = screen
+      .getByText("Subsidies")
+      .closest("span") as HTMLElement;
+    expect(subsidies).toHaveClass("bg-rmiblue-100");
+
+    // "Phaseout dates" is not selected
+    const phaseout = screen
+      .getByText("Phaseout dates")
+      .closest("span") as HTMLElement;
+    expect(phaseout).toHaveClass("bg-neutral-50");
+    expect(phaseout).not.toHaveClass("bg-rmiblue-100");
+  });
+
+  it("sentiment feature: selected value appears as a scale text label, not a blue pill", () => {
+    render(<KeyFeatures keyFeatures={mockKeyFeatures} />);
+
+    // "Moderate decrease" is the emissionsTrajectory value — rendered by SentimentScale
+    const label = screen.getByText("Moderate decrease");
+    expect(label).toHaveClass("text-rmigray-500");
+    expect(label).not.toHaveClass("bg-rmiblue-100");
+  });
+
+  it("neutral feature: selected value appears as a scale text label, not a blue pill", () => {
+    render(<KeyFeatures keyFeatures={mockKeyFeatures} />);
+
+    // "NDCs incl. conditional targets" is the policyAmbition value — rendered by NeutralScale
+    const label = screen.getByText("NDCs incl. conditional targets");
+    expect(label).toHaveClass("text-rmigray-500");
+    expect(label).not.toHaveClass("bg-rmiblue-100");
+  });
+});

--- a/src/components/KeyFeatures.tsx
+++ b/src/components/KeyFeatures.tsx
@@ -1,0 +1,384 @@
+import React from "react";
+import { PathwayMetadataType } from "../types";
+import { getKeyFeatureTooltip } from "../utils/tooltipUtils";
+import TextWithTooltip from "./TextWithTooltip";
+import SentimentScale from "./SentimentScale";
+import NeutralScale from "./NeutralScale";
+
+const PILL_SELECTED =
+  "inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium border bg-rmiblue-100 text-rmiblue-800 border-rmiblue-200 mr-2 mb-1";
+const PILL_UNSELECTED =
+  "inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium border bg-neutral-50 text-neutral-400 border-neutral-200 mr-2 mb-1";
+
+type FeatureKey = keyof PathwayMetadataType["keyFeatures"];
+
+interface SingleSelectFeatureConfig {
+  key: FeatureKey;
+  label: string;
+  type: "single-select";
+  options: string[];
+}
+
+interface MultiSelectFeatureConfig {
+  key: FeatureKey;
+  label: string;
+  type: "multi-select";
+  options: string[];
+}
+
+interface SentimentFeatureConfig {
+  key: FeatureKey;
+  label: string;
+  type: "sentiment";
+  scaleValues: string[];
+  greenEnd: "first" | "last";
+}
+
+interface NeutralFeatureConfig {
+  key: FeatureKey;
+  label: string;
+  type: "neutral";
+  scaleValues: string[];
+}
+
+type FeatureConfig =
+  | SingleSelectFeatureConfig
+  | MultiSelectFeatureConfig
+  | SentimentFeatureConfig
+  | NeutralFeatureConfig;
+
+interface GroupConfig {
+  label: string;
+  features: FeatureConfig[];
+}
+
+const GROUPS: GroupConfig[] = [
+  {
+    label: "Emissions Boundary & Trajectory",
+    features: [
+      {
+        key: "emissionsScope",
+        label: "Emissions scope",
+        type: "single-select",
+        options: [
+          "No information",
+          "CO2",
+          "CO2e (Kyoto)",
+          "CO2e (CO2, Methane)",
+          "CO2e (unspecified GHGs)",
+          "Other emissions scope",
+        ],
+      },
+      {
+        key: "emissionsTrajectory",
+        label: "Emissions trajectory",
+        type: "sentiment",
+        scaleValues: [
+          "Significant increase",
+          "Moderate increase",
+          "Minor increase",
+          "Low or no change",
+          "Minor decrease",
+          "Moderate decrease",
+          "Significant decrease",
+        ],
+        greenEnd: "last",
+      },
+    ],
+  },
+  {
+    label: "Energy System & Transition Levers",
+    features: [
+      {
+        key: "energyEfficiency",
+        label: "Energy efficiency",
+        type: "sentiment",
+        scaleValues: [
+          "Significant deterioration",
+          "Moderate deterioration",
+          "Minor deterioration",
+          "Low or no change",
+          "Minor improvement",
+          "Moderate improvement",
+          "Significant improvement",
+        ],
+        greenEnd: "last",
+      },
+      {
+        key: "energyDemand",
+        label: "Energy demand",
+        type: "sentiment",
+        scaleValues: [
+          "Significant decrease",
+          "Moderate decrease",
+          "Minor decrease",
+          "Low or no change",
+          "Minor increase",
+          "Moderate increase",
+          "Significant increase",
+        ],
+        greenEnd: "first",
+      },
+      {
+        key: "electrification",
+        label: "Electrification",
+        type: "sentiment",
+        scaleValues: [
+          "Significant decrease",
+          "Moderate decrease",
+          "Minor decrease",
+          "Low or no change",
+          "Minor increase",
+          "Moderate increase",
+          "Significant increase",
+        ],
+        greenEnd: "last",
+      },
+    ],
+  },
+  {
+    label: "Policy Environment",
+    features: [
+      {
+        key: "policyTypes",
+        label: "Policy types",
+        type: "multi-select",
+        options: [
+          "Carbon price",
+          "Feed-in tariffs",
+          "Performance standards",
+          "Phaseout dates",
+          "Subsidies",
+          "Target technology shares",
+          "Other",
+          "None",
+        ],
+      },
+      {
+        key: "policyAmbition",
+        label: "Policy ambition",
+        type: "neutral",
+        scaleValues: [
+          "No policies included",
+          "Current/legislated policies",
+          "Current and drafted policies",
+          "NDCs, unconditional only",
+          "NDCs incl. conditional targets",
+          "High ambition policies",
+          "Other policy ambition",
+        ],
+      },
+    ],
+  },
+  {
+    label: "Technology Assumptions",
+    features: [
+      {
+        key: "newTechnologiesIncluded",
+        label: "New technologies included",
+        type: "multi-select",
+        options: [
+          "No information",
+          "No new technologies",
+          "CCUS",
+          "DAC",
+          "Green H2/ammonia",
+          "SAF",
+          "Battery storage",
+          "EGS/AGS",
+          "Other new technologies",
+        ],
+      },
+      {
+        key: "technologyCostTrend",
+        label: "Technology cost trend",
+        type: "sentiment",
+        scaleValues: ["Increase", "Low or no change", "Decrease"],
+        greenEnd: "last",
+      },
+      {
+        key: "technologyCostsDetail",
+        label: "Technology costs detail",
+        type: "neutral",
+        scaleValues: [
+          "Total costs",
+          "Capital costs, O&M, etc.",
+          "Other cost breakdown",
+        ],
+      },
+      {
+        key: "investmentNeeds",
+        label: "Investment needs",
+        type: "neutral",
+        scaleValues: [
+          "Total investment",
+          "By sector",
+          "By sector, part of value chain",
+          "By technology",
+          "By tech, part of value chain",
+        ],
+      },
+    ],
+  },
+];
+
+interface FeatureItemProps {
+  feature: FeatureConfig;
+  keyFeatures: PathwayMetadataType["keyFeatures"];
+}
+
+const FeatureItem: React.FC<FeatureItemProps> = ({ feature, keyFeatures }) => {
+  const rawValue = keyFeatures[feature.key];
+
+  const label = (
+    <p className="text-xs font-medium text-rmigray-500 mb-1.5">
+      {feature.label}
+    </p>
+  );
+
+  if (feature.type === "single-select") {
+    const selected = rawValue as string;
+    return (
+      <div>
+        {label}
+        <div className="flex flex-wrap">
+          {feature.options.map((opt) => {
+            if (opt === selected) {
+              const tooltip = getKeyFeatureTooltip(feature.key, opt);
+              return tooltip ? (
+                <TextWithTooltip
+                  key={opt}
+                  text={<span className={PILL_SELECTED}>{opt}</span>}
+                  tooltip={tooltip}
+                  position="right"
+                />
+              ) : (
+                <span
+                  key={opt}
+                  className={PILL_SELECTED}
+                >
+                  {opt}
+                </span>
+              );
+            }
+            return (
+              <span
+                key={opt}
+                className={PILL_UNSELECTED}
+              >
+                {opt}
+              </span>
+            );
+          })}
+        </div>
+      </div>
+    );
+  }
+
+  if (feature.type === "multi-select") {
+    const selectedArr = (
+      Array.isArray(rawValue) ? rawValue : [rawValue]
+    ) as string[];
+    return (
+      <div>
+        {label}
+        <div className="flex flex-wrap">
+          {feature.options.map((opt) => {
+            if (selectedArr.includes(opt)) {
+              const tooltip = getKeyFeatureTooltip(feature.key, opt);
+              return tooltip ? (
+                <TextWithTooltip
+                  key={opt}
+                  text={<span className={PILL_SELECTED}>{opt}</span>}
+                  tooltip={tooltip}
+                  position="right"
+                />
+              ) : (
+                <span
+                  key={opt}
+                  className={PILL_SELECTED}
+                >
+                  {opt}
+                </span>
+              );
+            }
+            return (
+              <span
+                key={opt}
+                className={PILL_UNSELECTED}
+              >
+                {opt}
+              </span>
+            );
+          })}
+        </div>
+      </div>
+    );
+  }
+
+  if (feature.type === "sentiment") {
+    return (
+      <div>
+        {label}
+        <SentimentScale
+          values={feature.scaleValues}
+          selectedValue={rawValue as string}
+          greenEnd={feature.greenEnd}
+          tooltipGetter={(v) => getKeyFeatureTooltip(feature.key, v)}
+        />
+      </div>
+    );
+  }
+
+  if (feature.type === "neutral") {
+    return (
+      <div>
+        {label}
+        <NeutralScale
+          values={feature.scaleValues}
+          selectedValue={rawValue as string}
+          tooltipGetter={(v) => getKeyFeatureTooltip(feature.key, v)}
+        />
+      </div>
+    );
+  }
+
+  return null;
+};
+
+interface KeyFeaturesProps {
+  keyFeatures: PathwayMetadataType["keyFeatures"];
+}
+
+const KeyFeatures: React.FC<KeyFeaturesProps> = ({ keyFeatures }) => {
+  return (
+    <div className="bg-neutral-50 border border-neutral-200 rounded-lg p-4 mb-6">
+      <h3 className="text-lg font-medium text-rmigray-800 mb-3">
+        Key Features
+      </h3>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {GROUPS.map((group) => (
+          <div
+            key={group.label}
+            className="border border-neutral-200 rounded-md p-3 bg-white"
+          >
+            <h4 className="text-xs font-semibold text-rmigray-500 uppercase tracking-wide mb-3">
+              {group.label}
+            </h4>
+            <div className="space-y-4">
+              {group.features.map((feature) => (
+                <FeatureItem
+                  key={feature.key}
+                  feature={feature}
+                  keyFeatures={keyFeatures}
+                />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default KeyFeatures;

--- a/src/components/KeyFeatures.tsx
+++ b/src/components/KeyFeatures.tsx
@@ -171,7 +171,7 @@ const GROUPS: GroupConfig[] = [
     ],
   },
   {
-    label: "Technology Assumptions",
+    label: "Technology & Feasibility Assumptions",
     features: [
       {
         key: "newTechnologiesIncluded",

--- a/src/components/KeyFeatures.tsx
+++ b/src/components/KeyFeatures.tsx
@@ -244,21 +244,13 @@ const FeatureItem: React.FC<FeatureItemProps> = ({ feature, keyFeatures }) => {
         <div className="flex flex-wrap">
           {feature.options.map((opt) => {
             if (opt === selected) {
-              const tooltip = getKeyFeatureTooltip(feature.key, opt);
-              return tooltip ? (
+              return (
                 <TextWithTooltip
                   key={opt}
                   text={<span className={PILL_SELECTED}>{opt}</span>}
-                  tooltip={tooltip}
+                  tooltip={getKeyFeatureTooltip(feature.key, opt)}
                   position="right"
                 />
-              ) : (
-                <span
-                  key={opt}
-                  className={PILL_SELECTED}
-                >
-                  {opt}
-                </span>
               );
             }
             return (
@@ -285,21 +277,13 @@ const FeatureItem: React.FC<FeatureItemProps> = ({ feature, keyFeatures }) => {
         <div className="flex flex-wrap">
           {feature.options.map((opt) => {
             if (selectedArr.includes(opt)) {
-              const tooltip = getKeyFeatureTooltip(feature.key, opt);
-              return tooltip ? (
+              return (
                 <TextWithTooltip
                   key={opt}
                   text={<span className={PILL_SELECTED}>{opt}</span>}
-                  tooltip={tooltip}
+                  tooltip={getKeyFeatureTooltip(feature.key, opt)}
                   position="right"
                 />
-              ) : (
-                <span
-                  key={opt}
-                  className={PILL_SELECTED}
-                >
-                  {opt}
-                </span>
               );
             }
             return (

--- a/src/components/KeyFeatures.tsx
+++ b/src/components/KeyFeatures.tsx
@@ -352,15 +352,23 @@ interface KeyFeaturesProps {
 
 const KeyFeatures: React.FC<KeyFeaturesProps> = ({ keyFeatures }) => {
   return (
-    <div className="bg-neutral-50 border border-neutral-200 rounded-lg p-4 mb-6">
+    <div className="bg-neutral-50 border border-neutral-200 rounded-lg px-4 pt-4 pb-2 mb-6">
       <h3 className="text-lg font-medium text-rmigray-800 mb-3">
         Key Features
       </h3>
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        {GROUPS.map((group) => (
+      <div className="grid grid-cols-1 md:grid-cols-2">
+        {GROUPS.map((group, idx) => (
           <div
             key={group.label}
-            className="border border-neutral-200 rounded-md p-3 bg-white"
+            className={[
+              "py-4",
+              idx >= 2 ? "border-t border-neutral-200" : "",
+              idx % 2 === 1
+                ? "md:pl-6 md:border-l md:border-neutral-200"
+                : "md:pr-6",
+            ]
+              .filter(Boolean)
+              .join(" ")}
           >
             <h4 className="text-xs font-semibold text-rmigray-500 uppercase tracking-wide mb-3">
               {group.label}

--- a/src/components/KeyFeatures.tsx
+++ b/src/components/KeyFeatures.tsx
@@ -237,7 +237,10 @@ const FeatureItem: React.FC<FeatureItemProps> = ({ feature, keyFeatures }) => {
   );
 
   if (feature.type === "single-select") {
-    const selected = rawValue as string;
+    const selected =
+      typeof rawValue === "string" && feature.options.includes(rawValue)
+        ? rawValue
+        : "No information";
     return (
       <div>
         {label}
@@ -301,12 +304,16 @@ const FeatureItem: React.FC<FeatureItemProps> = ({ feature, keyFeatures }) => {
   }
 
   if (feature.type === "sentiment") {
+    const selectedValue =
+      typeof rawValue === "string" && rawValue.trim()
+        ? rawValue
+        : "No information";
     return (
       <div>
         {label}
         <SentimentScale
           values={feature.scaleValues}
-          selectedValue={rawValue as string}
+          selectedValue={selectedValue}
           greenEnd={feature.greenEnd}
           tooltipGetter={(v) => getKeyFeatureTooltip(feature.key, v)}
         />
@@ -315,12 +322,16 @@ const FeatureItem: React.FC<FeatureItemProps> = ({ feature, keyFeatures }) => {
   }
 
   if (feature.type === "neutral") {
+    const selectedValue =
+      typeof rawValue === "string" && rawValue.trim()
+        ? rawValue
+        : "No information";
     return (
       <div>
         {label}
         <NeutralScale
           values={feature.scaleValues}
-          selectedValue={rawValue as string}
+          selectedValue={selectedValue}
           tooltipGetter={(v) => getKeyFeatureTooltip(feature.key, v)}
         />
       </div>

--- a/src/components/NeutralScale.test.tsx
+++ b/src/components/NeutralScale.test.tsx
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import NeutralScale from "./NeutralScale";
+
+const VALUES = [
+  "No policies included",
+  "Current/legislated policies",
+  "Current and drafted policies",
+  "NDCs, unconditional only",
+  "NDCs incl. conditional targets",
+  "High ambition policies",
+  "Other policy ambition",
+];
+
+/** All segment divs in the scale bar (distinguished by rounded-sm, which only segments use). */
+function getSegments(container: HTMLElement): HTMLElement[] {
+  return Array.from(
+    container.querySelectorAll<HTMLElement>("[class*='rounded-sm']"),
+  );
+}
+
+describe("NeutralScale", () => {
+  it("renders the selected value as a text label below the scale", () => {
+    render(
+      <NeutralScale
+        values={VALUES}
+        selectedValue="NDCs incl. conditional targets"
+      />,
+    );
+    expect(
+      screen.getByText("NDCs incl. conditional targets"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders a 'No information' badge when selectedValue is 'No information'", () => {
+    render(
+      <NeutralScale
+        values={VALUES}
+        selectedValue="No information"
+      />,
+    );
+    expect(screen.getByText("No information")).toBeInTheDocument();
+  });
+
+  it("renders the correct number of segments", () => {
+    const { container } = render(
+      <NeutralScale
+        values={VALUES}
+        selectedValue="High ambition policies"
+      />,
+    );
+    expect(getSegments(container)).toHaveLength(VALUES.length);
+  });
+
+  it("selected segment has bg-rmiblue-400; all others have bg-neutral-200", () => {
+    const { container } = render(
+      <NeutralScale
+        values={VALUES}
+        selectedValue="High ambition policies"
+      />,
+    );
+    const segments = getSegments(container);
+    const selectedIndex = VALUES.indexOf("High ambition policies");
+
+    segments.forEach((seg, i) => {
+      if (i === selectedIndex) {
+        expect(seg).toHaveClass("bg-rmiblue-400");
+        expect(seg).not.toHaveClass("bg-neutral-200");
+      } else {
+        expect(seg).toHaveClass("bg-neutral-200");
+        expect(seg).not.toHaveClass("bg-rmiblue-400");
+      }
+    });
+  });
+
+  it("selected segment has h-3; all others have h-1.5", () => {
+    const { container } = render(
+      <NeutralScale
+        values={VALUES}
+        selectedValue="Current/legislated policies"
+      />,
+    );
+    const segments = getSegments(container);
+    const selectedIndex = VALUES.indexOf("Current/legislated policies");
+
+    segments.forEach((seg, i) => {
+      if (i === selectedIndex) {
+        expect(seg).toHaveClass("h-3");
+        expect(seg).not.toHaveClass("h-1.5");
+      } else {
+        expect(seg).toHaveClass("h-1.5");
+        expect(seg).not.toHaveClass("h-3");
+      }
+    });
+  });
+
+  it("all segments show bg-neutral-200 when value is 'No information'", () => {
+    const { container } = render(
+      <NeutralScale
+        values={VALUES}
+        selectedValue="No information"
+      />,
+    );
+    getSegments(container).forEach((seg) => {
+      expect(seg).toHaveClass("bg-neutral-200");
+      expect(seg).not.toHaveClass("bg-rmiblue-400");
+    });
+  });
+
+  it("calls tooltipGetter only with the selected value", () => {
+    const tooltipGetter = vi.fn().mockReturnValue("a tooltip");
+    render(
+      <NeutralScale
+        values={VALUES}
+        selectedValue="High ambition policies"
+        tooltipGetter={tooltipGetter}
+      />,
+    );
+    expect(tooltipGetter).toHaveBeenCalledWith("High ambition policies");
+    expect(tooltipGetter).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call tooltipGetter when value is 'No information'", () => {
+    const tooltipGetter = vi.fn();
+    render(
+      <NeutralScale
+        values={VALUES}
+        selectedValue="No information"
+        tooltipGetter={tooltipGetter}
+      />,
+    );
+    expect(tooltipGetter).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/NeutralScale.tsx
+++ b/src/components/NeutralScale.tsx
@@ -14,7 +14,8 @@ const NeutralScale: React.FC<NeutralScaleProps> = ({
   selectedValue,
   tooltipGetter,
 }) => {
-  const isNoInfo = selectedValue === "No information";
+  const isNoInfo =
+    selectedValue === "No information" || !values.includes(selectedValue);
   const selectedIndex = values.indexOf(selectedValue);
 
   const tooltip =

--- a/src/components/NeutralScale.tsx
+++ b/src/components/NeutralScale.tsx
@@ -30,7 +30,7 @@ const NeutralScale: React.FC<NeutralScaleProps> = ({
           return (
             <div
               key={value}
-              style={{ flex: isSelected ? 2 : 1 }}
+              style={{ flex: 1 }}
               className={`${isSelected ? "h-3" : "h-1.5"} rounded-sm ${
                 isSelected ? "bg-rmiblue-400" : "bg-neutral-200"
               }`}

--- a/src/components/NeutralScale.tsx
+++ b/src/components/NeutralScale.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import TextWithTooltip from "./TextWithTooltip";
+import Badge from "./Badge";
+
+interface NeutralScaleProps {
+  /** Ordered scale values, excluding "No information" */
+  values: string[];
+  selectedValue: string;
+  tooltipGetter?: (value: string) => string;
+}
+
+const NeutralScale: React.FC<NeutralScaleProps> = ({
+  values,
+  selectedValue,
+  tooltipGetter,
+}) => {
+  const isNoInfo = selectedValue === "No information";
+  const selectedIndex = values.indexOf(selectedValue);
+
+  const tooltip =
+    !isNoInfo && selectedValue && tooltipGetter
+      ? tooltipGetter(selectedValue)
+      : undefined;
+
+  return (
+    <div>
+      <div className="flex gap-0.5 items-center">
+        {values.map((value, i) => {
+          const isSelected = !isNoInfo && i === selectedIndex;
+          return (
+            <div
+              key={value}
+              style={{ flex: isSelected ? 2 : 1 }}
+              className={`${isSelected ? "h-3" : "h-1.5"} rounded-sm ${
+                isSelected ? "bg-rmiblue-400" : "bg-neutral-200"
+              }`}
+            />
+          );
+        })}
+      </div>
+      <div className="mt-1.5">
+        {isNoInfo ? (
+          <Badge>No information</Badge>
+        ) : selectedValue && selectedIndex >= 0 ? (
+          tooltip ? (
+            <TextWithTooltip
+              text={
+                <span className="text-xs text-rmigray-500 cursor-help">
+                  {selectedValue}
+                </span>
+              }
+              tooltip={tooltip}
+              position="right"
+            />
+          ) : (
+            <span className="text-xs text-rmigray-500">{selectedValue}</span>
+          )
+        ) : null}
+      </div>
+    </div>
+  );
+};
+
+export default NeutralScale;

--- a/src/components/SentimentScale.test.tsx
+++ b/src/components/SentimentScale.test.tsx
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import SentimentScale from "./SentimentScale";
+
+const VALUES_7 = [
+  "Significant increase",
+  "Moderate increase",
+  "Minor increase",
+  "Low or no change",
+  "Minor decrease",
+  "Moderate decrease",
+  "Significant decrease",
+];
+
+const VALUES_3 = ["Increase", "Low or no change", "Decrease"];
+
+/** All segment divs in the scale bar (distinguished by rounded-sm, which only segments use). */
+function getSegments(container: HTMLElement): HTMLElement[] {
+  return Array.from(
+    container.querySelectorAll<HTMLElement>("[class*='rounded-sm']"),
+  );
+}
+
+describe("SentimentScale", () => {
+  it("renders the selected value as a text label below the scale", () => {
+    render(
+      <SentimentScale
+        values={VALUES_7}
+        selectedValue="Moderate decrease"
+        greenEnd="last"
+      />,
+    );
+    expect(screen.getByText("Moderate decrease")).toBeInTheDocument();
+  });
+
+  it("renders a 'No information' badge when selectedValue is 'No information'", () => {
+    render(
+      <SentimentScale
+        values={VALUES_7}
+        selectedValue="No information"
+        greenEnd="last"
+      />,
+    );
+    expect(screen.getByText("No information")).toBeInTheDocument();
+  });
+
+  it("renders the correct number of segments", () => {
+    const { container } = render(
+      <SentimentScale
+        values={VALUES_7}
+        selectedValue="Moderate decrease"
+        greenEnd="last"
+      />,
+    );
+    expect(getSegments(container)).toHaveLength(VALUES_7.length);
+  });
+
+  it("selected segment has h-3; all others have h-1.5", () => {
+    const { container } = render(
+      <SentimentScale
+        values={VALUES_7}
+        selectedValue="Moderate decrease"
+        greenEnd="last"
+      />,
+    );
+    const segments = getSegments(container);
+    const selectedIndex = VALUES_7.indexOf("Moderate decrease");
+
+    segments.forEach((seg, i) => {
+      if (i === selectedIndex) {
+        expect(seg).toHaveClass("h-3");
+        expect(seg).not.toHaveClass("h-1.5");
+      } else {
+        expect(seg).toHaveClass("h-1.5");
+        expect(seg).not.toHaveClass("h-3");
+      }
+    });
+  });
+
+  it("all segments have opacity-20 when value is 'No information'", () => {
+    const { container } = render(
+      <SentimentScale
+        values={VALUES_7}
+        selectedValue="No information"
+        greenEnd="last"
+      />,
+    );
+    getSegments(container).forEach((seg) => {
+      expect(seg).toHaveClass("opacity-20");
+    });
+  });
+
+  it("only the selected segment lacks opacity-20 when a real value is selected", () => {
+    const { container } = render(
+      <SentimentScale
+        values={VALUES_7}
+        selectedValue="Minor decrease"
+        greenEnd="last"
+      />,
+    );
+    const segments = getSegments(container);
+    const selectedIndex = VALUES_7.indexOf("Minor decrease");
+
+    segments.forEach((seg, i) => {
+      if (i === selectedIndex) {
+        expect(seg).not.toHaveClass("opacity-20");
+      } else {
+        expect(seg).toHaveClass("opacity-20");
+      }
+    });
+  });
+
+  it("calls tooltipGetter only with the selected value", () => {
+    const tooltipGetter = vi.fn().mockReturnValue("a tooltip");
+    render(
+      <SentimentScale
+        values={VALUES_7}
+        selectedValue="Minor decrease"
+        greenEnd="last"
+        tooltipGetter={tooltipGetter}
+      />,
+    );
+    expect(tooltipGetter).toHaveBeenCalledWith("Minor decrease");
+    expect(tooltipGetter).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call tooltipGetter when value is 'No information'", () => {
+    const tooltipGetter = vi.fn();
+    render(
+      <SentimentScale
+        values={VALUES_7}
+        selectedValue="No information"
+        greenEnd="last"
+        tooltipGetter={tooltipGetter}
+      />,
+    );
+    expect(tooltipGetter).not.toHaveBeenCalled();
+  });
+
+  it("works correctly with a 3-step scale", () => {
+    const { container } = render(
+      <SentimentScale
+        values={VALUES_3}
+        selectedValue="Decrease"
+        greenEnd="last"
+      />,
+    );
+    expect(getSegments(container)).toHaveLength(3);
+    expect(screen.getByText("Decrease")).toBeInTheDocument();
+  });
+});

--- a/src/components/SentimentScale.tsx
+++ b/src/components/SentimentScale.tsx
@@ -7,13 +7,13 @@ const COLORS_7 = [
   "bg-rmired-400",
   "bg-rmired-200",
   "bg-rmired-100",
-  "bg-neutral-300",
+  "bg-neutral-400",
   "bg-success-400",
   "bg-success-600",
   "bg-success-800",
 ];
 
-const COLORS_3 = ["bg-rmired-400", "bg-neutral-300", "bg-success-600"];
+const COLORS_3 = ["bg-rmired-400", "bg-neutral-400", "bg-success-600"];
 
 interface SentimentScaleProps {
   /** Ordered scale values, excluding "No information" */
@@ -50,8 +50,8 @@ const SentimentScale: React.FC<SentimentScaleProps> = ({
           return (
             <div
               key={value}
-              style={{ flex: isSelected ? 2 : 1 }}
-              className={`${isSelected ? "h-3" : "h-1.5"} rounded-sm ${colors[i] ?? "bg-neutral-300"} ${
+              style={{ flex: 1 }}
+              className={`${isSelected ? "h-3" : "h-1.5"} rounded-sm ${colors[i] ?? "bg-neutral-400"} ${
                 isNoInfo || !isSelected ? "opacity-20" : ""
               }`}
             />

--- a/src/components/SentimentScale.tsx
+++ b/src/components/SentimentScale.tsx
@@ -1,0 +1,84 @@
+import React from "react";
+import TextWithTooltip from "./TextWithTooltip";
+import Badge from "./Badge";
+
+// Segment colors ordered from unfavorable (index 0) to favorable (index n-1)
+const COLORS_7 = [
+  "bg-rmired-400",
+  "bg-rmired-200",
+  "bg-rmired-100",
+  "bg-neutral-300",
+  "bg-success-400",
+  "bg-success-600",
+  "bg-success-800",
+];
+
+const COLORS_3 = ["bg-rmired-400", "bg-neutral-300", "bg-success-600"];
+
+interface SentimentScaleProps {
+  /** Ordered scale values, excluding "No information" */
+  values: string[];
+  selectedValue: string;
+  /** Which end of the values array is the favorable/green end */
+  greenEnd: "first" | "last";
+  tooltipGetter?: (value: string) => string;
+}
+
+const SentimentScale: React.FC<SentimentScaleProps> = ({
+  values,
+  selectedValue,
+  greenEnd,
+  tooltipGetter,
+}) => {
+  const isNoInfo = selectedValue === "No information";
+  const selectedIndex = values.indexOf(selectedValue);
+
+  // Build per-position color array. Base is unfavorable→favorable; reverse if first value is favorable.
+  const baseColors = values.length === 3 ? [...COLORS_3] : [...COLORS_7];
+  const colors = greenEnd === "first" ? baseColors.reverse() : baseColors;
+
+  const tooltip =
+    !isNoInfo && selectedValue && tooltipGetter
+      ? tooltipGetter(selectedValue)
+      : undefined;
+
+  return (
+    <div>
+      <div className="flex gap-0.5 items-center">
+        {values.map((value, i) => {
+          const isSelected = !isNoInfo && i === selectedIndex;
+          return (
+            <div
+              key={value}
+              style={{ flex: isSelected ? 2 : 1 }}
+              className={`${isSelected ? "h-3" : "h-1.5"} rounded-sm ${colors[i] ?? "bg-neutral-300"} ${
+                isNoInfo || !isSelected ? "opacity-20" : ""
+              }`}
+            />
+          );
+        })}
+      </div>
+      <div className="mt-1.5">
+        {isNoInfo ? (
+          <Badge>No information</Badge>
+        ) : selectedValue && selectedIndex >= 0 ? (
+          tooltip ? (
+            <TextWithTooltip
+              text={
+                <span className="text-xs text-rmigray-500 cursor-help">
+                  {selectedValue}
+                </span>
+              }
+              tooltip={tooltip}
+              position="right"
+            />
+          ) : (
+            <span className="text-xs text-rmigray-500">{selectedValue}</span>
+          )
+        ) : null}
+      </div>
+    </div>
+  );
+};
+
+export default SentimentScale;

--- a/src/components/SentimentScale.tsx
+++ b/src/components/SentimentScale.tsx
@@ -30,7 +30,8 @@ const SentimentScale: React.FC<SentimentScaleProps> = ({
   greenEnd,
   tooltipGetter,
 }) => {
-  const isNoInfo = selectedValue === "No information";
+  const isNoInfo =
+    selectedValue === "No information" || !values.includes(selectedValue);
   const selectedIndex = values.indexOf(selectedValue);
 
   // Build per-position color array. Base is unfavorable→favorable; reverse if first value is favorable.

--- a/src/pages/PathwayDetailPage.tsx
+++ b/src/pages/PathwayDetailPage.tsx
@@ -16,8 +16,8 @@ import {
   getPathwayTypeTooltip,
   getSectorTooltip,
   getMetricTooltip,
-  getKeyFeatureTooltip,
 } from "../utils/tooltipUtils";
+import KeyFeatures from "../components/KeyFeatures";
 import DownloadDataset from "../components/DownloadDataset";
 import {
   fetchTimeseriesIndex,
@@ -255,67 +255,7 @@ const PathwayDetailPage: React.FC = () => {
                 className="mb-6"
               />
 
-              <div className="bg-neutral-50 border border-neutral-200 rounded-lg p-4 mb-6">
-                <h3 className="text-lg font-medium text-rmigray-800 mb-3">
-                  Key Features
-                </h3>
-                {(() => {
-                  // Pretty labels for keys from schema (kept small & explicit to avoid surprises)
-                  const LABELS: Record<
-                    keyof PathwayMetadataType["keyFeatures"],
-                    string
-                  > = {
-                    emissionsTrajectory: "Emissions trajectory",
-                    energyEfficiency: "Energy efficiency",
-                    energyDemand: "Energy demand",
-                    electrification: "Electrification",
-                    policyTypes: "Policy types",
-                    technologyCostTrend: "Technology cost trend",
-                    technologyDeploymentTrend: "Technology deployment trend",
-                    emissionsScope: "Emissions scope",
-                    policyAmbition: "Policy ambition",
-                    technologyCostsDetail: "Technology costs detail",
-                    newTechnologiesIncluded: "New technologies included",
-                    supplyChain: "Supply chain",
-                    investmentNeeds: "Investment needs",
-                    infrastructureRequirements: "Infrastructure requirements",
-                  };
-
-                  return Object.entries(
-                    pathway.keyFeatures as string | string[],
-                  ).map(([rawKey, rawVal]) => {
-                    const key =
-                      rawKey as keyof PathwayMetadataType["keyFeatures"];
-                    // Normalize to an array of strings for BadgeArray
-                    const values = Array.isArray(rawVal) ? rawVal : [rawVal];
-                    // Defensive guard for any accidental empties
-                    const clean = values.filter((v): v is string =>
-                      Boolean(v && String(v).trim()),
-                    );
-                    if (clean.length === 0) return null;
-
-                    return (
-                      <div
-                        key={rawKey}
-                        className="mb-3"
-                      >
-                        <p className="text-xs font-medium text-rmigray-500 mb-1">
-                          {LABELS[key] ?? rawKey}
-                        </p>
-                        <BadgeArray
-                          variant="keyFeature"
-                          visibleCount={Infinity}
-                          tooltipGetter={(v: string) =>
-                            getKeyFeatureTooltip(key, v)
-                          }
-                        >
-                          {clean}
-                        </BadgeArray>
-                      </div>
-                    );
-                  });
-                })()}
-              </div>
+              <KeyFeatures keyFeatures={pathway.keyFeatures} />
 
               <div className="bg-neutral-50 border border-neutral-200 rounded-lg p-4 mb-6">
                 <h3 className="text-lg font-medium text-rmigray-800 mb-3">


### PR DESCRIPTION
closes #830 

* Replaces the flat badge list on PathwayDetailPage with a grouped 2×2 layout
* Key features are now rendered as single-select pills, multi-select pills, sentiment scales (green/red gradient), or neutral scales (grey/navy) depending on the variable
* All options are always visible; only the selected value carries a tooltip
* Includes unit tests for all three new components.