### PR TITLE
Feat/filter regions

### DIFF
--- a/src/pages/PathwaySearch.test.tsx
+++ b/src/pages/PathwaySearch.test.tsx
@@ -71,7 +71,9 @@ describe("PathwaySearch integration: dropdowns render and filter with 'None'", (
       id: "B",
       name: { full: "Pathway B", short: "Power, Europe, 2°C" },
       sectors: [{ name: "Power" }],
-      geography: { regions: { Europe: [] } },
+      // Geography matches by ISO overlap now, so coverage carries real codes.
+      // "Europe" here is represented by Germany (DE), "Asia" by Japan (JP).
+      geography: { country: ["DE"] },
       modelTempIncrease: 2,
       pathwayType: "Net Zero",
       modelYearNetzero: 2050,
@@ -93,7 +95,7 @@ describe("PathwaySearch integration: dropdowns render and filter with 'None'", (
       id: "D",
       name: { full: "Pathway D", short: "Steel, Asia, no temp" },
       sectors: [{ name: "Steel" }],
-      geography: { regions: { Asia: [] } },
+      geography: { country: ["JP"] },
       modelTempIncrease: undefined, // -> Temperature "None"
       pathwayType: "BAU",
       modelYearNetzero: 2030,
@@ -104,7 +106,7 @@ describe("PathwaySearch integration: dropdowns render and filter with 'None'", (
       id: "E",
       name: { full: "Pathway E", short: "Power, Europe+Asia, 2°C" },
       sectors: [{ name: "Power" }],
-      geography: { regions: { Europe: [], Asia: [] } },
+      geography: { country: ["DE", "JP"] },
       modelTempIncrease: 2,
       pathwayType: "Net Zero",
       modelYearNetzero: 2050,
@@ -229,12 +231,13 @@ describe("PathwaySearch integration: dropdowns render and filter with 'None'", (
     ]);
   });
 
-  it("Geography: ANY vs ALL toggle affects results (Europe + Asia)", async () => {
+  it("Geography: ANY vs ALL toggle affects results (Germany + Japan)", async () => {
     await openDropdown(/geography/i);
-    await selectOption("Europe");
-    await selectOption("Asia");
+    // Select two country options; matching is by ISO overlap.
+    await selectOption("Germany");
+    await selectOption("Japan");
 
-    // ANY (default): shows anything with Europe OR Asia → B, D, E
+    // ANY (default): shows anything covering DE OR JP → B, D, E
     expectVisible([
       "Power, Europe, 2°C",
       "Steel, Asia, no temp",
@@ -243,7 +246,7 @@ describe("PathwaySearch integration: dropdowns render and filter with 'None'", (
 
     // Switch to ALL inside the open menu
     await u.click(screen.getByTestId("mode-toggle"));
-    // Only E has both Europe and Asia
+    // Only E covers both DE and JP
     expectVisible(["Power, Europe+Asia, 2°C"]);
     expectHidden([
       "Power, Europe, 2°C",

--- a/src/utils/filterRegions.test.ts
+++ b/src/utils/filterRegions.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import {
+  ALL_COUNTRY_CODES,
+  FILTER_REGIONS,
+  FILTER_REGION_LABELS,
+  filterRegionToISO,
+} from "./filterRegions";
+import { countryCodeSchema } from "../schema/common";
+
+const ENUM = new Set(countryCodeSchema.enum as string[]);
+
+describe("filterRegions config (#798 seed)", () => {
+  it("Southeast Asia is exactly the ten ASEAN member states", () => {
+    // Grounded: IEA WEO 2024 Annex C. Order-independent comparison.
+    expect([...FILTER_REGIONS["Southeast Asia"]].sort()).toEqual(
+      ["BN", "ID", "KH", "LA", "MM", "MY", "PH", "SG", "TH", "VN"].sort(),
+    );
+  });
+
+  it("every defined region member is a valid schema country code", () => {
+    for (const [label, codes] of Object.entries(FILTER_REGIONS)) {
+      for (const code of codes) {
+        expect(ENUM.has(code), `${label} → ${code}`).toBe(true);
+      }
+    }
+  });
+
+  it("region members are unique within each region", () => {
+    for (const [label, codes] of Object.entries(FILTER_REGIONS)) {
+      expect(new Set(codes).size, label).toBe(codes.length);
+    }
+  });
+});
+
+describe("filterRegionToISO", () => {
+  it("expands Global to every recognised country code", () => {
+    const global = filterRegionToISO("Global");
+    expect(global.length).toBe(ENUM.size);
+    expect(new Set(global)).toEqual(ENUM);
+  });
+
+  it("resolves a defined region to its membership", () => {
+    expect(filterRegionToISO("Southeast Asia")).toContain("TH");
+    expect(filterRegionToISO("Southeast Asia")).toHaveLength(10);
+  });
+
+  it("returns a fresh array that cannot mutate the shared config", () => {
+    const first = filterRegionToISO("Southeast Asia");
+    first.push("US");
+    expect(filterRegionToISO("Southeast Asia")).toHaveLength(10);
+  });
+
+  it("Global is a strict superset of Southeast Asia (containment holds)", () => {
+    const global = new Set(filterRegionToISO("Global"));
+    for (const code of filterRegionToISO("Southeast Asia")) {
+      expect(global.has(code)).toBe(true);
+    }
+  });
+});
+
+describe("exports", () => {
+  it("FILTER_REGION_LABELS lists the defined regions and excludes Global", () => {
+    expect(FILTER_REGION_LABELS).toContain("Southeast Asia");
+    expect(FILTER_REGION_LABELS).not.toContain("Global");
+  });
+
+  it("ALL_COUNTRY_CODES matches the schema enum", () => {
+    expect(ALL_COUNTRY_CODES.length).toBe(ENUM.size);
+  });
+});

--- a/src/utils/filterRegions.test.ts
+++ b/src/utils/filterRegions.test.ts
@@ -99,7 +99,18 @@ describe("selectedGeographyToISO", () => {
   });
 
   it("returns an empty ISO set for an unknown/legacy token (never throws)", () => {
-    for (const token of ["Europe", "South East Asia", "XX", "USA", ""]) {
+    // Includes Object.prototype keys: an `in` check would misread these as
+    // regions and throw on `new Set(fn)`; an own-property check must not.
+    for (const token of [
+      "Europe",
+      "South East Asia",
+      "XX",
+      "USA",
+      "",
+      "toString",
+      "constructor",
+      "hasOwnProperty",
+    ]) {
       const r = selectedGeographyToISO(token);
       expect(r).toEqual({ kind: "iso", iso: new Set() });
     }

--- a/src/utils/filterRegions.test.ts
+++ b/src/utils/filterRegions.test.ts
@@ -4,7 +4,9 @@ import {
   FILTER_REGIONS,
   FILTER_REGION_LABELS,
   filterRegionToISO,
+  selectedGeographyToISO,
 } from "./filterRegions";
+import { ABSENT_FILTER_TOKEN } from "./absent";
 import { countryCodeSchema } from "../schema/common";
 
 const ENUM = new Set(countryCodeSchema.enum as string[]);
@@ -66,5 +68,40 @@ describe("exports", () => {
 
   it("ALL_COUNTRY_CODES matches the schema enum", () => {
     expect(ALL_COUNTRY_CODES.length).toBe(ENUM.size);
+  });
+});
+
+describe("selectedGeographyToISO", () => {
+  it("classifies the ABSENT token", () => {
+    expect(selectedGeographyToISO(ABSENT_FILTER_TOKEN)).toEqual({
+      kind: "absent",
+    });
+  });
+
+  it("classifies 'Global' (case-insensitive)", () => {
+    expect(selectedGeographyToISO("Global")).toEqual({ kind: "global" });
+    expect(selectedGeographyToISO("global")).toEqual({ kind: "global" });
+  });
+
+  it("expands a defined region label to its ISO members", () => {
+    const r = selectedGeographyToISO("Southeast Asia");
+    expect(r.kind).toBe("iso");
+    if (r.kind === "iso") {
+      expect([...r.iso].sort()).toEqual(
+        [...FILTER_REGIONS["Southeast Asia"]].sort(),
+      );
+    }
+  });
+
+  it("expands a valid ISO country code to a singleton set", () => {
+    const r = selectedGeographyToISO("TH");
+    expect(r).toEqual({ kind: "iso", iso: new Set(["TH"]) });
+  });
+
+  it("returns an empty ISO set for an unknown/legacy token (never throws)", () => {
+    for (const token of ["Europe", "South East Asia", "XX", "USA", ""]) {
+      const r = selectedGeographyToISO(token);
+      expect(r).toEqual({ kind: "iso", iso: new Set() });
+    }
   });
 });

--- a/src/utils/filterRegions.ts
+++ b/src/utils/filterRegions.ts
@@ -106,7 +106,9 @@ export type SelectedGeography =
  */
 export function selectedGeographyToISO(value: string): SelectedGeography {
   if (value === ABSENT_FILTER_TOKEN) return { kind: "absent" };
-  if (value in FILTER_REGIONS) {
+  // Own-property check, not `in`: `in` walks the prototype chain, so tokens
+  // like "toString" would be misread as regions and throw on `new Set(fn)`.
+  if (Object.hasOwn(FILTER_REGIONS, value)) {
     return {
       kind: "iso",
       iso: new Set(FILTER_REGIONS[value as keyof typeof FILTER_REGIONS]),

--- a/src/utils/filterRegions.ts
+++ b/src/utils/filterRegions.ts
@@ -18,6 +18,12 @@
  */
 import { countryCodeSchema } from "../schema/common";
 import type { GeographyCode } from "../types";
+import { ABSENT_FILTER_TOKEN } from "./absent";
+import {
+  toISO2,
+  countryNameFromISO2,
+  normalizeGeography,
+} from "./geographyUtils";
 
 /**
  * Every ISO-3166-1 alpha-2 code recognised by the repo's schema. Canonical source
@@ -77,3 +83,44 @@ export function filterRegionToISO(label: FilterRegionLabel): GeographyCode[] {
 export const FILTER_REGION_LABELS = Object.keys(
   FILTER_REGIONS,
 ) as (keyof typeof FILTER_REGIONS)[];
+
+/**
+ * A single selected geography-filter token, classified for matching.
+ * - `absent` — the "None" bucket (pathways with no geography).
+ * - `global` — the special "Global" label (matches only whole-world pathways).
+ * - `iso` — a concrete ISO set: a defined region's members, a single country
+ *   code, or the empty set for an unrecognised token (which then matches
+ *   nothing, so stale/legacy selections degrade safely rather than throwing).
+ */
+export type SelectedGeography =
+  | { kind: "absent" }
+  | { kind: "global" }
+  | { kind: "iso"; iso: Set<GeographyCode> };
+
+/**
+ * Classify one selected dropdown value into its match descriptor. This is the
+ * query-side counterpart of {@link filterRegionToISO}: the search matcher (#783)
+ * and the #869 resolver both interpret a user selection through here so they
+ * share one vocabulary. Checked in order so the categories can't collide
+ * (region labels are multi-word, never two letters).
+ */
+export function selectedGeographyToISO(value: string): SelectedGeography {
+  if (value === ABSENT_FILTER_TOKEN) return { kind: "absent" };
+  if (value in FILTER_REGIONS) {
+    return {
+      kind: "iso",
+      iso: new Set(FILTER_REGIONS[value as keyof typeof FILTER_REGIONS]),
+    };
+  }
+  if (
+    normalizeGeography(value).toLowerCase() ===
+    GLOBAL_REGION_LABEL.toLowerCase()
+  ) {
+    return { kind: "global" };
+  }
+  const iso = toISO2(value);
+  if (iso && countryNameFromISO2(iso)) {
+    return { kind: "iso", iso: new Set([iso as GeographyCode]) };
+  }
+  return { kind: "iso", iso: new Set() };
+}

--- a/src/utils/filterRegions.ts
+++ b/src/utils/filterRegions.ts
@@ -1,0 +1,79 @@
+/**
+ * Filter regions (issue #798) — the predetermined vocabulary of regions a user
+ * can pick in the search dropdown, each mapped to its ISO-3166-1 alpha-2 members.
+ *
+ * This is the "query side" of best-effort geography search: #783 matches a
+ * selected filter region against each pathway's coverage by ISO overlap, and the
+ * #869 resolver uses the same sets to compute geography containment. Kept here as
+ * a plain, UI-independent map/util (per #797) so the dropdown and the resolver can
+ * share one source of truth rather than duplicating region logic in the component.
+ *
+ * ⚠️ WORK IN PROGRESS — this is the beginning of #798, seeded with only the
+ * regions that have a grounded, published definition, so downstream work (#783
+ * filtering, #869 resolver) has real data to build and test against. The full
+ * vocabulary — the five continental regions, "East Asia and Pacific", and the
+ * individual countries — is still pending the finalized list under #798 and
+ * product sign-off before it is added here. "Asia Pacific" (already grounded to
+ * IEA WEO 2024 Annex C in the IEA pathway data) is the natural next addition.
+ */
+import { countryCodeSchema } from "../schema/common";
+import type { GeographyCode } from "../types";
+
+/**
+ * Every ISO-3166-1 alpha-2 code recognised by the repo's schema. Canonical source
+ * for the "Global" filter region (#798: "a 'Global' region that maps to all ISO
+ * 3166 codes"), derived from the schema enum so it can never drift from the codes
+ * pathways are actually allowed to use.
+ */
+export const ALL_COUNTRY_CODES: readonly GeographyCode[] = Object.freeze(
+  (countryCodeSchema.enum as GeographyCode[] | undefined) ?? [],
+);
+
+/**
+ * Multi-country filter regions with a grounded, publication-sourced membership.
+ * Keyed by the user-facing label; values are ISO-3166-1 alpha-2 codes. The
+ * `satisfies` clause makes TypeScript reject any code that is not a valid
+ * `GeographyCode`, so a typo'd member fails the build.
+ */
+export const FILTER_REGIONS = {
+  /**
+   * The ten member states of ASEAN. Grounded: IEA World Energy Outlook 2024,
+   * Annex C — "Southeast Asia: Brunei Darussalam, Cambodia, Indonesia, Lao PDR,
+   * Malaysia, Myanmar, Philippines, Singapore, Thailand and Viet Nam. These
+   * countries are all members of [ASEAN]." Matches the ACE (AEO8) and
+   * TransitionZero (TZ-APG) pathway coverage already in this repo.
+   */
+  "Southeast Asia": [
+    "BN",
+    "KH",
+    "ID",
+    "LA",
+    "MY",
+    "MM",
+    "PH",
+    "SG",
+    "TH",
+    "VN",
+  ],
+} as const satisfies Record<string, readonly GeographyCode[]>;
+
+/** A recognised filter-region label: a defined multi-country region or "Global". */
+export type FilterRegionLabel = keyof typeof FILTER_REGIONS | "Global";
+
+/** The special label whose membership is every recognised country code. */
+export const GLOBAL_REGION_LABEL = "Global" as const;
+
+/**
+ * Resolve a filter-region label to its ISO-3166-1 alpha-2 member codes. "Global"
+ * expands to every code in the schema; a defined region returns its membership.
+ * Returns a fresh array so callers cannot mutate the shared config.
+ */
+export function filterRegionToISO(label: FilterRegionLabel): GeographyCode[] {
+  if (label === GLOBAL_REGION_LABEL) return [...ALL_COUNTRY_CODES];
+  return [...FILTER_REGIONS[label]];
+}
+
+/** Defined multi-country filter-region labels (excludes the special "Global"). */
+export const FILTER_REGION_LABELS = Object.keys(
+  FILTER_REGIONS,
+) as (keyof typeof FILTER_REGIONS)[];

--- a/src/utils/geographyUtils.test.tsx
+++ b/src/utils/geographyUtils.test.tsx
@@ -219,9 +219,11 @@ describe("pathwayISOCoverage", () => {
   });
 
   it("drops invalid / non-ISO entries and handles missing/empty geography", () => {
-    expect([...pathwayISOCoverage({ country: ["US", "USA", ""] })]).toEqual([
-      "US",
-    ]);
+    // "USA" (3 letters) and "" fail toISO2; "ZZ" is two letters but not a real
+    // country, so it must be dropped too (result is only recognised codes).
+    expect([
+      ...pathwayISOCoverage({ country: ["US", "USA", "", "ZZ"] }),
+    ]).toEqual(["US"]);
     expect(pathwayISOCoverage(undefined).size).toBe(0);
     expect(pathwayISOCoverage({}).size).toBe(0);
     expect(pathwayISOCoverage({ regions: { X: [] } }).size).toBe(0);

--- a/src/utils/geographyUtils.test.tsx
+++ b/src/utils/geographyUtils.test.tsx
@@ -4,6 +4,8 @@ import {
   sortGeographiesForDetails,
   normalizeGeography,
   assertKnownCountryISO2,
+  pathwayISOCoverage,
+  isGeographyAbsent,
 } from "./geographyUtils";
 import { makeGeographyOptions } from "./searchUtils";
 import type { PathwayMetadataType } from "../types";
@@ -200,5 +202,39 @@ describe("makeGeographyOptions", () => {
     const opts = makeGeographyOptions(pathways);
     expect(opts.map((o) => o.value)).toEqual(["CN"]);
     expect(opts.map((o) => o.label)).toEqual(["People's Republic of China"]);
+  });
+});
+
+describe("pathwayISOCoverage", () => {
+  it("unions country[] and all region members", () => {
+    const cov = pathwayISOCoverage({
+      regions: { "South East Asia": ["ID", "TH"], "Europe": ["DE"] },
+      country: ["US"],
+    });
+    expect([...cov].sort()).toEqual(["DE", "ID", "TH", "US"]);
+  });
+
+  it("does NOT expand the global flag (global-only → empty set)", () => {
+    expect(pathwayISOCoverage({ global: true }).size).toBe(0);
+  });
+
+  it("drops invalid / non-ISO entries and handles missing/empty geography", () => {
+    expect([...pathwayISOCoverage({ country: ["US", "USA", ""] })]).toEqual([
+      "US",
+    ]);
+    expect(pathwayISOCoverage(undefined).size).toBe(0);
+    expect(pathwayISOCoverage({}).size).toBe(0);
+    expect(pathwayISOCoverage({ regions: { X: [] } }).size).toBe(0);
+  });
+});
+
+describe("isGeographyAbsent", () => {
+  it("is true only when flattening yields no tokens", () => {
+    expect(isGeographyAbsent(undefined)).toBe(true);
+    expect(isGeographyAbsent({})).toBe(true);
+    // A region label with empty members is still PRESENT (carries a token).
+    expect(isGeographyAbsent({ regions: { X: [] } })).toBe(false);
+    expect(isGeographyAbsent({ global: true })).toBe(false);
+    expect(isGeographyAbsent({ country: ["US"] })).toBe(false);
   });
 });

--- a/src/utils/geographyUtils.ts
+++ b/src/utils/geographyUtils.ts
@@ -8,10 +8,10 @@ export type GeographyKind = "global" | "region" | "country";
 // Flatten the structured geography object into the ordered flat token list the
 // rest of the app historically operated on: "Global" (when global) → region
 // labels → country codes. This intentionally does NOT expand region membership
-// into countries — the canonical region→country intersection is a later phase.
-// In the current dataset the `regions` member arrays are deliberately left
-// empty (regions are carried only as labels, matching the pre-migration flat
-// list), so this flattening reproduces exactly the tokens the app saw before.
+// into countries — it carries regions as their label only. ISO-overlap
+// geography matching (#797) reads the populated `regions` member arrays via
+// `pathwayISOCoverage` instead; this function is still used for display tokens
+// (badges, sort) and the "absent geography" check (`isGeographyAbsent`).
 // `geographyKind`/`geographyLabel`/`sortGeographiesForDetails` continue to work
 // on the individual string tokens this returns.
 export function flattenGeography(geo: Geography | null | undefined): string[] {

--- a/src/utils/geographyUtils.ts
+++ b/src/utils/geographyUtils.ts
@@ -1,6 +1,6 @@
 import countries from "i18n-iso-countries";
 import en from "i18n-iso-countries/langs/en.json";
-import type { Geography } from "../types";
+import type { Geography, GeographyCode } from "../types";
 countries.registerLocale(en);
 
 export type GeographyKind = "global" | "region" | "country";
@@ -21,6 +21,42 @@ export function flattenGeography(geo: Geography | null | undefined): string[] {
   if (geo.regions) tokens.push(...Object.keys(geo.regions));
   if (geo.country) tokens.push(...geo.country);
   return tokens;
+}
+
+// The ISO-3166-1 alpha-2 codes a pathway actually covers: the union of its
+// standalone `country` list and the member codes of every `regions` entry.
+// Unlike `flattenGeography` (which carries region LABELS, not members), this is
+// the country-level expansion used for ISO-overlap geography matching. The
+// `global` flag is intentionally NOT expanded here — it is a separate boolean,
+// so a global-only pathway yields an empty coverage set (which is what makes
+// "a below-global filter never matches a global-only pathway" fall out for
+// free in the matcher). Invalid entries are dropped via `toISO2`.
+export function pathwayISOCoverage(
+  geo: Geography | null | undefined,
+): Set<GeographyCode> {
+  const codes = new Set<GeographyCode>();
+  if (!geo || typeof geo !== "object") return codes;
+  const add = (raw: string) => {
+    const iso = toISO2(raw);
+    if (iso) codes.add(iso as GeographyCode);
+  };
+  if (geo.country) geo.country.forEach(add);
+  if (geo.regions) {
+    for (const members of Object.values(geo.regions)) {
+      if (Array.isArray(members)) members.forEach(add);
+    }
+  }
+  return codes;
+}
+
+// A pathway has "absent" geography when flattening yields no tokens — i.e. an
+// empty/missing geography object (`{}`, `undefined`, or the legacy empty array).
+// Single source of truth shared by the "None" facet gate and the ABSENT match
+// arm so the two can never disagree about what counts as empty. Note a region
+// with an empty member array (e.g. `{regions:{X:[]}}`) is NOT absent — it still
+// carries a region label token.
+export function isGeographyAbsent(geo: Geography | null | undefined): boolean {
+  return flattenGeography(geo).length === 0;
 }
 
 //Normalize to a safe string: accept strings (and basic primitives), drop everything else.

--- a/src/utils/geographyUtils.ts
+++ b/src/utils/geographyUtils.ts
@@ -30,7 +30,9 @@ export function flattenGeography(geo: Geography | null | undefined): string[] {
 // `global` flag is intentionally NOT expanded here — it is a separate boolean,
 // so a global-only pathway yields an empty coverage set (which is what makes
 // "a below-global filter never matches a global-only pathway" fall out for
-// free in the matcher). Invalid entries are dropped via `toISO2`.
+// free in the matcher). Entries that aren't recognised ISO-3166-1 alpha-2
+// codes are dropped (`toISO2` + a name lookup), so the result only ever holds
+// real country codes — matching the query side (`selectedGeographyToISO`).
 export function pathwayISOCoverage(
   geo: Geography | null | undefined,
 ): Set<GeographyCode> {
@@ -38,7 +40,7 @@ export function pathwayISOCoverage(
   if (!geo || typeof geo !== "object") return codes;
   const add = (raw: string) => {
     const iso = toISO2(raw);
-    if (iso) codes.add(iso as GeographyCode);
+    if (iso && countryNameFromISO2(iso)) codes.add(iso as GeographyCode);
   };
   if (geo.country) geo.country.forEach(add);
   if (geo.regions) {

--- a/src/utils/searchUtils.test.tsx
+++ b/src/utils/searchUtils.test.tsx
@@ -1,7 +1,12 @@
 import { describe, it, expect } from "vitest";
-import { filterPathways, getGlobalFacetOptions } from "./searchUtils";
+import {
+  filterPathways,
+  getGlobalFacetOptions,
+  geographyFilterOptions,
+} from "./searchUtils";
 import type { FiltersWithArrays } from "./searchUtils";
 import { ABSENT_FILTER_TOKEN } from "./absent";
+import { FILTER_REGION_LABELS, ALL_COUNTRY_CODES } from "./filterRegions";
 import { PathwayMetadataType, SearchFilters } from "../types";
 
 import sample01 from "../../testdata/valid/pathwayMetadata_sample_01.json" assert { type: "json" };
@@ -159,13 +164,12 @@ const mockFullPathways: PathwayMetadataType[] = [rawFullPathway];
 describe("searchUtils - array results", () => {
   //
   // Mock pathway data
-  const geography: string[] = [
-    "Global",
-    "Europe and Central Asia",
-    "North America",
-    "South East Asia",
-    "US",
-  ];
+  // Tokens from the #797 filter vocabulary that all resolve, by ISO overlap, to
+  // the full pathway's coverage ({DE,FR,GB,US,CA,MX,ID,TH,VN} + global):
+  //   "Global"          → whole-world flag
+  //   "Southeast Asia"  → defined filter region; overlaps SEA members ID/TH/VN
+  //   "DE"/"CA"/"US"    → ISO codes present via region members / standalone
+  const geography: string[] = ["Global", "Southeast Asia", "DE", "CA", "US"];
 
   const sectors: string[] = [
     "Land Use",
@@ -299,24 +303,26 @@ describe("filterPathways (array-backed facets)", () => {
   });
 
   it("geography: ALL mode requires all tokens; ANY is default", () => {
-    // Add a pathway with two geos
+    // Matching is by ISO overlap, so use country codes: B covers DE, C covers
+    // JP, and B2 covers both.
     const many: PathwayMetadataType[] = [
-      ...pathways,
+      { ...pathways[1], id: "B", name: "B", geography: { country: ["DE"] } },
+      { ...pathways[2], id: "C", name: "C", geography: { country: ["JP"] } },
       {
         ...pathways[1],
         id: "B2",
         name: "B2",
-        geography: { regions: { Europe: [], Asia: [] } },
+        geography: { country: ["DE", "JP"] },
       },
     ];
-    // ANY (default): Europe OR Asia → B, C, B2
+    // ANY (default): DE OR JP → B, C, B2
     let out = filterPathways(many, {
-      geography: ["Europe", "Asia"],
+      geography: ["DE", "JP"],
     });
     expect(out.map((s) => s.id)).toEqual(["B", "C", "B2"]);
-    // ALL: must have both → only B2
+    // ALL: must cover both → only B2
     out = filterPathways(many, {
-      geography: ["Europe", "Asia"],
+      geography: ["DE", "JP"],
       modes: { geography: "ALL" },
     });
     expect(out.map((s) => s.id)).toEqual(["B2"]);
@@ -508,5 +514,148 @@ describe("getGlobalFacetOptions", () => {
     expect(sectorOptions.map((o) => o.label)).toContain("None");
     // geographyOptions uses withAbsentOption; presence of ABSENT is encoded as an extra option
     expect(geographyOptions.map((o) => o.label)).toContain("None");
+  });
+});
+
+describe("geography ISO-overlap matching (#797/#783)", () => {
+  // Fixtures with POPULATED region members — matching is by ISO overlap, so
+  // empty-member regions carry no coverage. Note SEA uses the pathway spelling
+  // "South East Asia" while the filter vocabulary uses "Southeast Asia": the
+  // matcher compares ISO members, never the label string.
+  const p = (
+    id: string,
+    geography: PathwayMetadataType["geography"],
+  ): PathwayMetadataType =>
+    ({ id, name: id, geography }) as PathwayMetadataType;
+
+  const pathways: PathwayMetadataType[] = [
+    p("g", { global: true }),
+    p("sea", { regions: { "South East Asia": ["ID", "TH", "VN"] } }),
+    p("cn", { country: ["CN"] }),
+    p("mix", {
+      global: true,
+      regions: { "Europe and Central Asia": ["DE", "FR"] },
+      country: ["US"],
+    }),
+    p("mix2", {
+      global: true,
+      regions: { "South East Asia": ["TH"] },
+      country: ["US"],
+    }),
+    p("empty", {}),
+    p("emptyreg", { regions: { "South East Asia": [] } }),
+  ];
+  const ids = (f: SearchFilters) =>
+    filterPathways(pathways, f).map((x) => x.id);
+
+  it("'Global' keeps only whole-world pathways", () => {
+    expect(ids({ geography: ["Global"] })).toEqual(["g", "mix", "mix2"]);
+  });
+
+  it("a defined region matches by ISO overlap and excludes global-only pathways", () => {
+    // "Southeast Asia" (10 ASEAN codes) overlaps sea (ID/TH/VN) and mix2 (TH),
+    // but not the global-only 'g' (empty coverage) despite its global flag.
+    expect(ids({ geography: ["Southeast Asia"] })).toEqual(["sea", "mix2"]);
+  });
+
+  it("region label spelling differences don't matter (ISO members compared)", () => {
+    // sea's key is "South East Asia"; the filter label is "Southeast Asia".
+    expect(ids({ geography: ["Southeast Asia"] })).toContain("sea");
+  });
+
+  it("a single country code matches via country and via region members", () => {
+    expect(ids({ geography: ["CN"] })).toEqual(["cn"]);
+    // US appears as a standalone country of mix/mix2.
+    expect(ids({ geography: ["US"] })).toEqual(["mix", "mix2"]);
+  });
+
+  it("a country present only in a region's members still matches", () => {
+    // DE is a member of mix's "Europe and Central Asia" region, not its country[].
+    expect(ids({ geography: ["DE"] })).toEqual(["mix"]);
+  });
+
+  it("an unknown/legacy token matches nothing and never throws", () => {
+    expect(ids({ geography: ["Europe"] })).toEqual([]);
+  });
+
+  it("a valid ISO code no pathway covers yields no matches", () => {
+    expect(ids({ geography: ["AQ"] })).toEqual([]);
+  });
+
+  it("ABSENT/'None' matches only empty geography, not empty-member regions", () => {
+    expect(ids({ geography: [ABSENT_FILTER_TOKEN] })).toEqual(["empty"]);
+  });
+
+  it("ANY unions selections; ALL requires overlap with every selection", () => {
+    expect(ids({ geography: ["Southeast Asia", "US"] })).toEqual([
+      "sea",
+      "mix",
+      "mix2",
+    ]);
+    expect(
+      ids({
+        geography: ["Southeast Asia", "US"],
+        modes: { geography: "ALL" },
+      }),
+    ).toEqual(["mix2"]);
+  });
+
+  it("ALL with Global + a region needs both the global flag and ISO overlap", () => {
+    expect(
+      ids({
+        geography: ["Global", "Southeast Asia"],
+        modes: { geography: "ALL" },
+      }),
+    ).toEqual(["mix2"]);
+  });
+
+  it("ALL with ABSENT + a concrete code is unsatisfiable", () => {
+    expect(
+      ids({
+        geography: [ABSENT_FILTER_TOKEN, "CN"],
+        modes: { geography: "ALL" },
+      }),
+    ).toEqual([]);
+  });
+
+  it("no geography filter returns everything", () => {
+    expect(ids({ geography: [] }).length).toBe(pathways.length);
+  });
+});
+
+describe("geographyFilterOptions (#797 dropdown vocabulary)", () => {
+  it("is the fixed filter vocabulary: Global + defined regions + all ISO countries", () => {
+    const opts = geographyFilterOptions();
+    expect(opts.length).toBe(
+      1 + FILTER_REGION_LABELS.length + ALL_COUNTRY_CODES.length,
+    );
+    const values = opts.map((o) => o.value);
+    expect(values).toContain("Global");
+    expect(values).toContain("Southeast Asia");
+    expect(values).toContain("CN");
+    expect(values).toContain("US");
+  });
+
+  it("is NOT derived from pathway data (all-global dataset still lists countries)", () => {
+    const onlyGlobal: PathwayMetadataType[] = [
+      { ...mockPathways[0], id: "g", geography: { global: true } },
+    ];
+    const { geographyOptions } = getGlobalFacetOptions(onlyGlobal);
+    // TH/Southeast Asia are absent from the dataset yet still offered.
+    expect(geographyOptions.map((o) => o.value)).toContain("TH");
+    expect(geographyOptions.map((o) => o.value)).toContain("Southeast Asia");
+  });
+
+  it("orders Global first, then regions, then countries; labels countries by name", () => {
+    const opts = geographyFilterOptions();
+    expect(opts[0].value).toBe("Global");
+    const firstCountryIdx = opts.findIndex((o) => /^[A-Z]{2}$/.test(o.value));
+    const regionIdx = opts.findIndex((o) => o.value === "Southeast Asia");
+    expect(regionIdx).toBeGreaterThan(0);
+    expect(regionIdx).toBeLessThan(firstCountryIdx);
+    // Country options carry a display name, not the raw code.
+    const us = opts.find((o) => o.value === "US");
+    expect(us?.label).not.toBe("US");
+    expect(us?.label?.length).toBeGreaterThan(2);
   });
 });

--- a/src/utils/searchUtils.ts
+++ b/src/utils/searchUtils.ts
@@ -4,7 +4,15 @@ import {
   geographyLabel,
   sortGeographiesForDetails,
   flattenGeography,
+  pathwayISOCoverage,
+  isGeographyAbsent,
 } from "./geographyUtils";
+import {
+  FILTER_REGION_LABELS,
+  GLOBAL_REGION_LABEL,
+  ALL_COUNTRY_CODES,
+  selectedGeographyToISO,
+} from "./filterRegions";
 import { matchesOptionalFacetAny, matchesOptionalFacetAll } from "./facets";
 import { ABSENT_FILTER_TOKEN } from "./absent";
 import { buildOptionsFromValues, hasAbsent, withAbsentOption } from "./facets";
@@ -38,8 +46,10 @@ export function getGlobalFacetOptions(pathways: PathwayMetadataType[]) {
     pathways.map((d) => d.modelTempIncrease),
   );
 
-  // Geography (structured options via makeGeographyOptions)
-  const geographyOptionsRaw: GeoOption[] = makeGeographyOptions(pathways);
+  // Geography: the dropdown vocabulary is the predetermined filter-region set
+  // (#797/#783) — "Global", every defined multi-country region, and all ISO
+  // countries — sourced from filterRegions.ts, NOT scanned from pathway data.
+  const geographyOptionsRaw: GeoOption[] = geographyFilterOptions();
   // A pathway counts as "absent" geography (surfacing the "None" facet) when
   // flattening yields no tokens — i.e. an empty/missing geography object. Note
   // this is stricter than the old flat-array model, where an empty `[]` was
@@ -163,6 +173,26 @@ function matchesNumericRange(
   return gteMin && lteMax;
 }
 
+// The geography dropdown vocabulary (#797). Fixed, publication-independent set:
+// "Global", every defined multi-country filter region, and all ISO countries —
+// so the same region can be filtered regardless of how any single pathway named
+// it, and countries a pathway never lists are still selectable. Sorted
+// global → regions → countries (A→Z) and labelled via geographyLabel (country
+// full names; "Global"/region labels pass through). The ABSENT/"None" option is
+// added separately by the caller, gated on the data actually having gaps.
+export function geographyFilterOptions(): GeoOption[] {
+  const values: string[] = [
+    GLOBAL_REGION_LABEL,
+    ...FILTER_REGION_LABELS,
+    ...ALL_COUNTRY_CODES,
+  ];
+  const sorted = sortGeographiesForDetails(values);
+  return sorted.map((v) => ({ value: v, label: geographyLabel(v) }));
+}
+
+// NOTE (#797): superseded by geographyFilterOptions as the dropdown source —
+// the vocabulary no longer comes from scanning pathway data. Kept (and still
+// unit-tested) for now; safe to remove in a follow-up once no longer referenced.
 export function makeGeographyOptions(
   pathways: PathwayMetadataType[],
 ): GeoOption[] {
@@ -328,25 +358,55 @@ export const filterPathways = (
       }
     }
 
-    // Geography filter (array + mode + missing-aware + normalization)
+    // Geography filter (#797/#783): match by ISO-code overlap, not label text.
+    // Each selection is expanded to its ISO set (region → members, country →
+    // singleton, "Global" → special, "None" → the empty-geography bucket) and
+    // compared against the pathway's ISO coverage. This is inclusion only —
+    // ranking/containment scoring belongs to #869.
     {
       const selected = toArray(filters.geography);
-      const norm = (s: string) => normalizeGeography(s).toUpperCase();
-      // IMPORTANT: preserve the ABSENT token; only normalize concrete selections
-      const normalizedSelected = selected.map((t) =>
-        t === ABSENT_FILTER_TOKEN ? t : norm(t),
-      );
-      const mode = pickMode("geography", filters.modes);
-      const geographyTokens = flattenGeography(pathway.geography);
-      const ok =
-        mode === "ALL"
-          ? matchesOptionalFacetAll(normalizedSelected, geographyTokens, (g) =>
-              norm(g),
-            )
-          : matchesOptionalFacetAny(normalizedSelected, geographyTokens, (g) =>
-              norm(g),
-            );
-      if (!ok) return false;
+      if (selected.length > 0) {
+        const mode = pickMode("geography", filters.modes);
+
+        let wantAbsent = false;
+        let wantGlobal = false;
+        const isoSets: Set<string>[] = [];
+        for (const token of selected) {
+          const d = selectedGeographyToISO(token);
+          if (d.kind === "absent") wantAbsent = true;
+          else if (d.kind === "global") wantGlobal = true;
+          else isoSets.push(d.iso);
+        }
+
+        const geo = pathway.geography;
+        const pGlobal = !!(
+          geo &&
+          typeof geo === "object" &&
+          !Array.isArray(geo) &&
+          geo.global === true
+        );
+        const pCoverage = pathwayISOCoverage(geo);
+        const pAbsent = isGeographyAbsent(geo);
+
+        // An empty selection set (unknown/legacy token) overlaps nothing, so a
+        // stale selection can never spuriously match — and a global-only
+        // pathway has empty coverage, so a below-global filter never keeps it.
+        const overlaps = (set: Set<string>) => {
+          if (set.size === 0) return false;
+          for (const code of set) if (pCoverage.has(code)) return true;
+          return false;
+        };
+
+        const ok =
+          mode === "ALL"
+            ? (!wantAbsent || pAbsent) &&
+              (!wantGlobal || pGlobal) &&
+              isoSets.every(overlaps)
+            : (wantAbsent && pAbsent) ||
+              (wantGlobal && pGlobal) ||
+              isoSets.some(overlaps);
+        if (!ok) return false;
+      }
     }
 
     // Sector filter (array + mode + missing-aware)


### PR DESCRIPTION
## Feat: filter regions

Adds a fixed, publication-independent **geography filter vocabulary** and switches
geography filtering from label matching to ISO-3166 country-coverage overlap.

Part of #783 (geography axis of epic #860). Implements #797 and seeds pathway
region data toward #798.

### What changed

**Filter-region config + util (#797)**
- New `src/utils/filterRegions.ts`: the dropdown vocabulary (`Global`, defined
  multi-country regions, all ISO-3166-1 alpha-2 countries) as a UI-independent
  source of truth, typed against the schema enum.
- `filterRegionToISO(label)` and `selectedGeographyToISO(value)` classify a
  selection into its ISO set — reusable by the #869 resolver.

**Search integration (#797 / #783)**
- The geography dropdown now sources its options from `filterRegions.ts` instead
  of scanning pathway data.
- `filterPathways` matches by **ISO overlap**, not label text: a selected region
  expands to its member codes and is compared against each pathway's coverage.
  - `Global` matches only whole-world pathways.
  - Below-global selections never match global-only pathways.
  - Spelling differences between publications (e.g. "South East Asia" vs
    "Southeast Asia") no longer matter — matching is on ISO members.
- New helpers `pathwayISOCoverage` / `isGeographyAbsent` in `geographyUtils.ts`.

**Pathway region data (toward #798)**
- Grounded region → ISO mappings for ACE (AEO8), TransitionZero (TZ-APG), and
  IEA WEO 2024 (STEPS, APS).

### Scope / boundaries

Inclusion only — ranking, cost, and containment resolution are **out of scope**
and remain in #869, which consumes the utilities added here.

### Testing

- Unit + integration tests for ISO-overlap matching, dropdown vocabulary, and the
  new helpers.
- Verified in the running app: `Southeast Asia` → 55 pathways (the 1 global-only
  pathway correctly excluded); `Global` → 14.
- `tsc`, `eslint`, `prettier`, and the full suite (410 tests) all pass.